### PR TITLE
Coverage Thresholds

### DIFF
--- a/PHP/CodeCoverage/Report/HTML.php
+++ b/PHP/CodeCoverage/Report/HTML.php
@@ -106,6 +106,14 @@ class PHP_CodeCoverage_Report_HTML
             $options['generator'] = '';
         }
 
+        if (!isset($options['methodCoverageThreshold'])) {
+            $options['methodCoverageThreshold'] = 100;
+        }
+
+        if (!isset($options['classCoverageThreshold'])) {
+            $options['classCoverageThreshold'] = 100;
+        }
+
         $this->options = $options;
 
         self::$templatePath = sprintf(
@@ -210,7 +218,10 @@ class PHP_CodeCoverage_Report_HTML
                       substr($key, 0, -2),
                       $value,
                       $this->options['yui'],
-                      $this->options['highlight']
+                      $this->options['highlight'],
+                      $this->options['methodCoverageThreshold'],
+                      $this->options['classCoverageThreshold']
+
                     );
                 }
 

--- a/PHP/CodeCoverage/Report/HTML/Node/Directory.php
+++ b/PHP/CodeCoverage/Report/HTML/Node/Directory.php
@@ -146,13 +146,15 @@ class PHP_CodeCoverage_Report_HTML_Node_Directory extends PHP_CodeCoverage_Repor
      * @param  array   $lines
      * @param  boolean $yui
      * @param  boolean $highlight
+     * @param  string $methodCoverageThreshold
+     * @param  string $classCoverageThreshold
      * @return PHP_CodeCoverage_Report_HTML_Node_File
      * @throws RuntimeException
      */
-    public function addFile($name, array $lines, $yui, $highlight)
+    public function addFile($name, array $lines, $yui, $highlight, $methodCoverageThreshold, $classCoverageThreshold)
     {
         $file = new PHP_CodeCoverage_Report_HTML_Node_File(
-          $name, $this, $lines, $yui, $highlight
+          $name, $this, $lines, $yui, $highlight, $methodCoverageThreshold, $classCoverageThreshold
         );
 
         $this->children[] = $file;

--- a/PHP/CodeCoverage/Report/HTML/Node/File.php
+++ b/PHP/CodeCoverage/Report/HTML/Node/File.php
@@ -138,6 +138,16 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
      */
     protected $endLines = array();
 
+	/**
+	* @var string
+	*/
+	protected $methodCoverageThreshold;
+
+	/**
+	* @var string
+	*/
+	protected $classCoverageThreshold;
+
     /**
      * Constructor.
      *
@@ -146,9 +156,11 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
      * @param  array                             $executedLines
      * @param  boolean                           $yui
      * @param  boolean                           $highlight
+	 * @param  string							 $methodCoverageThreshold
+	 * @param  string							 $classCoverageThreshold
      * @throws RuntimeException
      */
-    public function __construct($name, PHP_CodeCoverage_Report_HTML_Node $parent, array $executedLines, $yui = TRUE, $highlight = FALSE)
+    public function __construct($name, PHP_CodeCoverage_Report_HTML_Node $parent, array $executedLines, $yui = TRUE, $highlight = FALSE, $methodCoverageThreshold = 100, $classCoverageThreshold = 100)
     {
         parent::__construct($name, $parent);
 
@@ -167,7 +179,9 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
         $this->ignoredLines  = PHP_CodeCoverage_Util::getLinesToBeIgnored(
                                  $path
                                );
-
+		$this->methodCoverageThreshold = $methodCoverageThreshold;
+		$this->classCoverageThreshold = $classCoverageThreshold;
+		
         $this->calculateStatistics();
     }
 
@@ -391,7 +405,7 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
         $items = '';
 
         foreach ($this->classes as $className => $classData) {
-            if ($classData['executedLines'] == $classData['executableLines']) {
+            if ($classData['coverage'] >= $this->classCoverageThreshold) {
                 $numTestedClasses     = 1;
                 $testedClassesPercent = 100;
             } else {
@@ -403,7 +417,8 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
             $numMethods       = count($classData['methods']);
 
             foreach ($classData['methods'] as $method) {
-                if ($method['executedLines'] == $method['executableLines']) {
+				
+                if ($method['coverage'] >= $this->methodCoverageThreshold) {
                     $numTestedMethods++;
                 }
             }
@@ -439,8 +454,8 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
             );
 
             foreach ($classData['methods'] as $methodData) {
-                if ($methodData['executedLines'] ==
-                    $methodData['executableLines']) {
+
+                if ($methodData['coverage'] >= $this->methodCoverageThreshold) {
                     $numTestedMethods     = 1;
                     $testedMethodsPercent = 100;
                 } else {
@@ -595,7 +610,7 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
                     $method['coverage'] = 100;
                 }
 
-                if ($method['coverage'] == 100) {
+                if ($method['coverage'] >= $this->methodCoverageThreshold) {
                     $this->numTestedMethods++;
                 }
 
@@ -614,7 +629,7 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
                     $class['coverage'] = 100;
                 }
 
-                if ($class['coverage'] == 100) {
+                if ($class['coverage'] >= $this->classCoverageThreshold) {
                     $this->numTestedClasses++;
                 }
 


### PR DESCRIPTION
I have added support to configure the threshold that makes a method or class be marked as tested. Currently 100% of method lines need to be tested before its marked as tested, but i have ran into a few situations where its impossible to get that 100% (either bad design or xdebug issues) so the method remains marked as not tested.

With this patch i can specify that if 90% of lines are tasted the method can then be accepted as tested, much like the low and high bounds.

Question:
I was able to add the 2 options to the HTML reports and all the way down to the File.php, however i did not figure out how to call this option from the command line like --html ./_reports --methodCoverageThreshold 90 or something like that, other then registering the option itself, and i thought it should be available as the yui and highlight methods are.

Let me know if this sounds useful or it violates some basic rule of testing, if you think its useful, i'll finish up the unit tests for it. Still running phpunit 3.4 here so i had a few issues running the suite.

Cheers! Pity you are leaving Orlando before i get there on sunday, we could have scheduled a dinner, well next year at tek hopefully.
