### PR TITLE
Fixed false data and removed the need for file inclusion

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -563,9 +563,10 @@ class PHP_CodeCoverage
                 $oldVariableNames = array_keys(get_defined_vars());
             }
 
-            $this->driver->start();
-            include_once $uncoveredFile;
-            $coverage = $this->driver->stop();
+            $fileContents = file($uncoveredFile);
+            $coverage = array(
+                $uncoveredFile => array_pad(array(), count($fileContents), -1)
+            );
 
             if ($this->promoteGlobals) {
                 $newVariables = get_defined_vars();


### PR DESCRIPTION
When parsing the white-list for coverage, you used xdebug. This resulted two things:
1) There were coverage data without executing 1 piece of test code.
2) Legacy codes can't be tested because of great deal of dependency.

I've modified the CodeCoverage.php to create an empty coverage data out of whitelisted files. This way the  execution of the tests will generate the real coverage.
