### PR TITLE
Fixed false data and removed the need for file inclusion

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -338,9 +338,10 @@ class PHP_CodeCoverage
                     if ($test !== 0) {
                         // when overwriting a file in the empty dataset,
                         // rewrite instead of merge.
-                        if (in_array($file, $this->untouchedFiles)) {
+                        $untouchedIndex = array_search($file, $this->untouchedFiles);
+                        if (false !== $untouchedIndex) {
                             $this->summary[$file] = $lines;
-                            unset($this->untouchedFiles[$file]);
+                            unset($this->untouchedFiles[$untouchedIndex]);
                         }
                     }
                     foreach ($lines as $line => $flag) {


### PR DESCRIPTION
- Whitelisted files are not included anymore.
- With the new method, all untouched files have 0% coverage with all lines red.
- Once the file had ad least one coverage usage, the correct coverage data is shown.
- Can be used to generate reports for big legacy systems.
- No more need for blacklists when an included file would break the reporting.

I don't have the Sebastian coding standard, so I could not verify the CS sorry for that.
