### PR TITLE
Report refactoring

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/Template/directory_item.html.dist
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/Template/directory_item.html.dist
@@ -1,29 +1,23 @@
         <tr>
           <td class="{itemClass}">{icon}{name}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{lines_color}.png" width="{lines_executed_width}" height="10" alt="{lines_executed_percent}"><img src="snow.png" width="{lines_not_executed_width}" height="10" alt="{lines_executed_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+            <div class="coverBarOutline" title="{lines_executed_percent}">
+              <div class="size {lines_color}"  style="width:{lines_executed_width}%" title="{lines_executed_percent}"></div>
+            </div>
           </td>
           <td class="coverPer{lines_level}">{lines_executed_percent}</td>
           <td class="coverNum{lines_level}">{num_executed_lines} / {num_executable_lines}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{methods_color}.png" width="{methods_tested_width}" height="10" alt="{methods_tested_percent}"><img src="snow.png" width="{methods_not_tested_width}" height="10" alt="{methods_tested_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+            <div class="coverBarOutline" title="{methods_tested_percent}">
+                <div class="size {methods_color}"  style="width:{methods_tested_width}%" title="{methods_tested_percent}"></div>
+            </div>
           </td>
           <td class="coverPer{methods_level}">{methods_tested_percent}</td>
           <td class="coverNum{methods_level}">{methods_number}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{classes_color}.png" width="{classes_tested_width}" height="10" alt="{classes_tested_percent}"><img src="snow.png" width="{classes_not_tested_width}" height="10" alt="{classes_tested_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+              <div class="coverBarOutline" title="{classes_tested_percent}">
+                 <div class="size {classes_color}"  style="width:{classes_tested_width}%" title="{classes_tested_percent}"></div>
+              </div>
           </td>
           <td class="coverPer{classes_level}">{classes_tested_percent}</td>
           <td class="coverNum{classes_level}">{classes_number}</td>

--- a/PHP/CodeCoverage/Report/HTML/Renderer/Template/file_item.html.dist
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/Template/file_item.html.dist
@@ -1,30 +1,24 @@
         <tr>
           <td class="{itemClass}">{name}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{classes_color}.png" width="{classes_tested_width}" height="10" alt="{classes_tested_percent}"><img src="snow.png" width="{classes_not_tested_width}" height="10" alt="{classes_tested_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+             <div class="coverBarOutline" title="{classes_tested_percent}">
+                <div class="size {classes_color}"  style="width:{classes_tested_width}%" title="{classes_tested_percent}"></div>
+             </div>
           </td>
           <td class="coverPer{classes_level}">{classes_tested_percent}</td>
           <td class="coverNum{classes_level}">{classes_number}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{methods_color}.png" width="{methods_tested_width}" height="10" alt="{methods_tested_percent}"><img src="snow.png" width="{methods_not_tested_width}" height="10" alt="{methods_tested_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+            <div class="coverBarOutline" title="{methods_tested_percent}">
+                <div class="size {methods_color}"  style="width:{methods_tested_width}%" title="{methods_tested_percent}"></div>
+            </div>
           </td>
           <td class="coverPer{methods_level}">{methods_tested_percent}</td>
           <td class="coverNum{methods_level}">{methods_number}</td>
           <td class="crap">{crap}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{lines_color}.png" width="{lines_executed_width}" height="10" alt="{lines_executed_percent}"><img src="snow.png" width="{lines_not_executed_width}" height="10" alt="{lines_executed_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+            <div class="coverBarOutline" title="{lines_executed_percent}">
+                <div class="size {lines_color}"  style="width:{lines_executed_width}%" title="{lines_executed_percent}"></div>
+            </div>
           </td>
           <td class="coverPer{lines_level}">{lines_executed_percent}</td>
           <td class="coverNum{lines_level}">{num_executed_lines} / {num_executable_lines}</td>

--- a/PHP/CodeCoverage/Report/HTML/Renderer/Template/method_item.html.dist
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/Template/method_item.html.dist
@@ -1,21 +1,17 @@
         <tr>
           <td class="coverFile" colspan="4">{name}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{methods_color}.png" width="{methods_tested_width}" height="10" alt="{methods_tested_percent}"><img src="snow.png" width="{methods_not_tested_width}" height="10" alt="{methods_tested_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+            <div class="coverBarOutline" title="{methods_tested_percent}">
+                <div class="size {methods_color}"  style="width:{methods_tested_width}%" title="{methods_tested_percent}"></div>
+            </div>
           </td>
           <td class="coverPer{methods_level}">{methods_tested_percent}</td>
           <td class="coverNum{methods_level}">{methods_number}</td>
           <td class="crap">{crap}</td>
-          <td class="coverBar" align="center" width="100">
-            <table border="0" cellspacing="0" cellpadding="1">
-              <tr>
-                <td class="coverBarOutline"><img src="{lines_color}.png" width="{lines_executed_width}" height="10" alt="{lines_executed_percent}"><img src="snow.png" width="{lines_not_executed_width}" height="10" alt="{lines_executed_percent}"></td>
-              </tr>
-            </table>
+          <td class="coverBar">
+              <div class="coverBarOutline" title="{lines_executed_percent}">
+                  <div class="size {lines_color}"  style="width:{lines_executed_width}%" title="{lines_executed_percent}"></div>
+              </div>
           </td>
           <td class="coverPer{lines_level}">{lines_executed_percent}</td>
           <td class="coverNum{lines_level}">{num_executed_lines} / {num_executable_lines}</td>

--- a/PHP/CodeCoverage/Report/HTML/Renderer/Template/style.css
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/Template/style.css
@@ -127,12 +127,48 @@ td.coverBar
   padding-left: 10px;
   padding-right: 10px;
   background-color: #d3d7cf;
+  text-align:center;
+  width: 100px;
 }
 
 /* Directory view/File view (all): bar-graph outline color */
-td.coverBarOutline
+div.coverBarOutline
 {
-  background-color: #2e3436;
+  background-color: #fff;
+  border: 1px solid #2e3436;
+  height: 10px;
+  overflow:hidden;
+  width: 100px;
+}
+
+/* Directory view/File view (all): common style for bar-graph  */
+div.coverBarOutline div.size
+{
+    height: 10px; float:left;
+}
+
+/* Directory view/File view (all): bar-graph color no coverage rate */
+div.coverBarOutline div.snow
+{
+    background-color:#fff;
+}
+
+/* Directory view/File view (all): bar-graph color for low coverage rate */
+div.coverBarOutline div.scarlet_red
+{
+    background-color:#ef2929;
+}
+
+/* Directory view/File view (all): bar-graph color for middle coverage rate */
+div.coverBarOutline div.butter
+{
+    background-color:#fce94f;
+}
+
+/* Directory view/File view (all):  bar-graph color for high coverage rate */
+div.coverBarOutline div.chameleon
+{
+    background-color:#8ae234;
 }
 
 /* Directory view/File view (all): percentage entry for files with


### PR DESCRIPTION
Hi, Sebastian.

I think it's a good time to take out snow.png, scarlet_red.png, butter.png and chameleon.png images. I've reworked coverBarOutline using divs + css instead of tables + images. I am not sure if those images are still needed in the project so I've not deleted them. Please, delete them if they are not using anymore. 

Thank you for this cool tool.
