### PR TITLE
Enabled combination of forceCoversAnnotation and processUncoveredFilesFromWhitelist

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -435,13 +435,13 @@ class PHP_CodeCoverage
         }
 
         else if ($this->forceCoversAnnotation) {
-			if($this->processUncoveredFilesFromWhitelist) {
-				foreach(array_keys($data) as $filename) {
-					$data[$filename] = array();
-				}
-			} else {
-				$data = array();
-			}
+            if ($this->processUncoveredFilesFromWhitelist) {
+                foreach (array_keys($data) as $filename) {
+                    $data[$filename] = array();
+                }
+            } else {
+                $data = array();
+            }
         }
     }
 


### PR DESCRIPTION
When forceCoversAnnotation is activated, files are completely ignored in coverage reports, if they do not have any coverage at all. This means, they are missing from the report at all.

This shouldn't happend, if processUncoveredFilesFromWhitelist is activated at the same time.
Therefor I provided a little patch which puts all files into the coverage report, even if they did not have any covered code lines and processUncoveredFilesFromWhitelist is activated at the same time.
