### PR TITLE
Delete the source code from the token cache

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Node/File.php
+++ b/PHP/CodeCoverage/Report/HTML/Node/File.php
@@ -169,6 +169,8 @@ class PHP_CodeCoverage_Report_HTML_Node_File extends PHP_CodeCoverage_Report_HTM
                                );
 
         $this->calculateStatistics();
+
+        PHP_Token_Stream_CachingFactory::delete($path);
     }
 
     /**


### PR DESCRIPTION
Delete the source code from the token cache when we're done calculating statistics.  This greatly reduces memory usage when running coverage against many files.  When running tests against a subset of my codebase, this change reduced memory usage from ~900MB to ~300MB.  I paired on this work with my coworker, Mark French.
