### PR TITLE
Single lines may be ignored by appending "// @codeCoverageIgnore".

### DIFF
--- a/PHP/CodeCoverage/Util.php
+++ b/PHP/CodeCoverage/Util.php
@@ -253,8 +253,14 @@ class PHP_CodeCoverage_Util
                     case 'PHP_Token_COMMENT': {
                         $_token = trim($token);
 
-                        if ($_token == '// @codeCoverageIgnoreStart' ||
-                            $_token == '//@codeCoverageIgnoreStart') {
+                        if ($_token == '// @codeCoverageIgnore' ||
+                            $_token == '//@codeCoverageIgnore') {
+                            $ignore = TRUE;
+                            $stop   = TRUE;
+                        }
+
+                        else if ($_token == '// @codeCoverageIgnoreStart' ||
+                                 $_token == '//@codeCoverageIgnoreStart') {
                             $ignore = TRUE;
                         }
 

--- a/Tests/PHP/CodeCoverage/UtilTest.php
+++ b/Tests/PHP/CodeCoverage/UtilTest.php
@@ -207,7 +207,8 @@ class PHP_CodeCoverage_UtilTest extends PHPUnit_Framework_TestCase
             22 => TRUE,
             23 => TRUE,
             24 => TRUE,
-            25 => TRUE
+            25 => TRUE,
+            30 => TRUE
           ),
           PHP_CodeCoverage_Util::getLinesToBeIgnored(
             TEST_FILES_PATH . 'source_with_ignore.php'

--- a/Tests/_files/source_with_ignore.php
+++ b/Tests/_files/source_with_ignore.php
@@ -24,3 +24,8 @@ class Bar
     {
     }
 }
+
+function baz()
+{
+    print '*'; // @codeCoverageIgnore
+}


### PR DESCRIPTION
Sometimes you want to ignore a single line for code coverage, especially when calling methods that always throw exceptions such as PHPUnit_Framework_Assert::markTestSkipped(). For example, my base test case has a flag to tell it to skip all future tests due to a catastrophic error in a previous test. Before executing each test it checks for this condition:

```
private static function checkForSkipAllTests() {
    if (self::$_skipAllTests) {
        self::markTestSkipped();
    }
}
```

The first closing brace is marked as not covered because Xdebug doesn't know that it cannot be reached. The old solution is to surround it with ignore comments which makes it unreadable.

```
private static function checkForSkipAllTests() {
    if (self::$_skipAllTests) {
        self::markTestSkipped();
    // @codeCoverageIgnoreStart
    }
    // @codeCoverageIgnoreEnd
}
```

This commit improves the readability:

```
private static function checkForSkipAllTests() {
    if (self::$_skipAllTests) {
        self::markTestSkipped();
    } // @codeCoverageIgnore
}
```
