### PR TITLE
cleaning filename returned wrongly due to an XDebug bug

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -459,7 +459,9 @@ class PHP_CodeCoverage
             // Patch for XDebug bug:
             // http://bugs.xdebug.org/bug_view_page.php?bug_id=0000331
             preg_match('/.*\.php/', $file, $matches);
-            $file = $matches[0];
+            if(isset($matches[0])) {
+                $file = $matches[0];
+            }
 
             if ($this->filter->isFile($file) && !isset($this->data[$file])) {
                 $this->data[$file] = array();


### PR DESCRIPTION
XDebug has a bug which is causing the missing of some files in the php-code-coverage.

When there is an assert or an eval, XDebug returns a wrong file name, something like:

`/path/path/path/myClass.php(444) : assert code`

They have an open bug since 2007 so it seems that is very low priority for them and they don't have intentions to fix it:

http://bugs.xdebug.org/bug_view_page.php?bug_id=0000331

With the current approach of this coverage tool, if it's not a valid file (checked with $this->filter->isFile($file)), is not included in the coverage report and these files wrongly returned by XDebug, therefore, are missing. So this can be considered a bug.

This change just sanitize the file name returned by XDebug in order to consider them as valid so can be added to the coverage report.

I suppose the $this->filter->isFile($file) won't be necessary but i prefer to let you take the decision of its removal because maybe you prefer to keep it for other cases.
