### PR TITLE
strip out phar:// prefixes when parsing reducing paths

### DIFF
--- a/PHP/CodeCoverage/Report/Factory.php
+++ b/PHP/CodeCoverage/Report/Factory.php
@@ -229,6 +229,10 @@ class PHP_CodeCoverage_Report_Factory
         $max = count($paths);
 
         for ($i = 0; $i < $max; $i++) {
+            // strip phar:// prefixes
+            if (strpos($paths[$i], 'phar://') === 0) {
+                $paths[$i] = substr($paths[$i], 7);
+            }
             $paths[$i] = explode(DIRECTORY_SEPARATOR, $paths[$i]);
 
             if (empty($paths[$i][0])) {

--- a/Tests/PHP/CodeCoverage/Report/FactoryTest.php
+++ b/Tests/PHP/CodeCoverage/Report/FactoryTest.php
@@ -245,7 +245,20 @@ class PHP_CodeCoverage_Report_FactoryTest extends PHP_CodeCoverage_TestCase
             array(),
             '.',
             array()
-          )
+          ),
+          array(
+            array(
+              'Money.php' => array(),
+              'MoneyBag.php' => array(),
+              'Cash.phar/Cash.php' => array(), 
+            ),
+            '/home/sb/Money',
+            array(
+              '/home/sb/Money/Money.php' => array(),
+              '/home/sb/Money/MoneyBag.php' => array(),
+              'phar:///home/sb/Money/Cash.phar/Cash.php' => array(),
+            ), 
+          ),
         );
     }
 }


### PR DESCRIPTION
CodeCoverage isn't able to generate HTML reports correctly if the code it is
operating on includes phar:// paths as it cannot deduce a common path.

I ran into problems measuring code coverage on a project that contained phar files in a vendor/ directory - generating a report that could not be drilled down into like so:

http://dl.dropbox.com/u/217221/coverage_example.png

Thanks for considering this request.
