### PR TITLE
Incompatibility with File_Iterator 1.3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -138,6 +138,8 @@
     <name>File_Iterator</name>
     <channel>pear.phpunit.de</channel>
     <min>1.2.2</min>
+    <max>1.3.0</max>
+    <exclude>1.3.0</exclude>
    </package>
    <package>
     <name>PHP_TokenStream</name>


### PR DESCRIPTION
Using CodeCoverage 1.0 with File_Iterator 1.3 fails with the following errors:

```
Strict Standards: Non-static method File_Iterator_Factory::getFileIterator() should not be called statically, assuming $this from incompatible context in /usr/share/php/PHP/CodeCoverage/Filter.php on line 111
Fatal error: Class 'File_Iterator' not found in /usr/share/php/File/Iterator/Factory.php on line 105
```

Using a version less than 1.3.0 fixes this.
