### PR TITLE
Requiring MultiplePcreFilterIterator

### DIFF
--- a/PHP/CodeCoverage/Autoload.php
+++ b/PHP/CodeCoverage/Autoload.php
@@ -45,6 +45,7 @@
 
 require_once 'Symfony/Component/Finder/Finder.php';
 require_once 'Symfony/Component/Finder/Glob.php';
+require_once 'Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php';
 require_once 'Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php';
 require_once 'Symfony/Component/Finder/Iterator/FilenameFilterIterator.php';
 require_once 'Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php';


### PR DESCRIPTION
Requiring MultiplePcreFilterIterator because Symfony [master] now extends FilenameFilterIterator:

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
