### PR TITLE
Support parenthesis in the covers annotation

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -633,7 +633,7 @@ class PHP_CodeCoverage
         }
 
         $match = preg_match_all(
-          '(@covers\s+(?P<coveredElement>.*?)\s*$)m',
+          '(@covers\s+(?P<coveredElement>.*?)\s*(\(\s*\))?\s*$)m',
           $docComment,
           $matches
         );

--- a/Tests/PHP/CodeCoverageTest.php
+++ b/Tests/PHP/CodeCoverageTest.php
@@ -82,7 +82,7 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
         $this->getLinesToBeCovered = new ReflectionMethod(
           'PHP_CodeCoverage', 'getLinesToBeCovered'
         );
- 
+
         $this->getLinesToBeCovered->setAccessible(TRUE);
     }
 
@@ -235,10 +235,13 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
     }
 
     /**
-     * @covers PHP_CodeCoverage::start
-     * @covers PHP_CodeCoverage::stop
-     * @covers PHP_CodeCoverage::append
-     * @covers PHP_CodeCoverage::applyListsFilter
+     * Add parenthesis to the covers annotation below in a couple of different ways to make sure it
+     * works as expected
+     *
+     * @covers PHP_CodeCoverage::start()
+     * @covers PHP_CodeCoverage::stop( )
+     * @covers PHP_CodeCoverage::append ()
+     * @covers PHP_CodeCoverage::applyListsFilter ( )
      * @covers PHP_CodeCoverage::initializeFilesThatAreSeenTheFirstTime
      * @covers PHP_CodeCoverage::applyCoversAnnotationFilter
      * @covers PHP_CodeCoverage::getTests


### PR DESCRIPTION
With this PR the covers annotation can have parenthesis after method names:

``` php
<?php
class SomeTest extends PHPUnit_Framework_TestCase {
    /**
     * @covers SomeClass::test()
     */
    public function testSomething() {

    }
}
```

Without this support the error message is quite misleading as it says:

`Trying to @cover not existing method "SomeClass::test()".`

when the `test()` method clearly exists.

I'm not too sure about how to go about testing this, so I changed some of the covers annotations in the CodeCoverageTest.php test case to include the supported ways of using the parenthesis.
