### PR TITLE
Re-enable source code indentation

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/Template/css/style.css
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/Template/css/style.css
@@ -14,6 +14,11 @@ body {
  border: 0 !important;
 }
 
+.table-condensed td {
+ font-family: monospace;
+ white-space: pre;
+}
+
 .table tbody td.success, li.success, span.success {
  background-color: #dff0d8;
 }


### PR DESCRIPTION
Use of « font-family: monospace » and « white-space: pre » to re-indent the code.

CSS taken from php-code-coverage 1.1.3
