### PR TITLE
Remove doubled backslashes from code coverage popovers.

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/File.php
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/File.php
@@ -385,7 +385,7 @@ class PHP_CodeCoverage_Report_HTML_Renderer_File extends PHP_CodeCoverage_Report
                           '<li%s>%s</li>',
 
                           $testCSS,
-                          addslashes(htmlspecialchars($test))
+                          htmlspecialchars($test)
                         );
                     }
 


### PR DESCRIPTION
Namespaced tests result in double backslashes in the coverage popover, since addslashes() is called on the list item. As far as I can tell, this is unnecessary, since the item is already htmlspecialchars()'d and is used in a data-content attribute, so this patch removes it.

It seems to work fine here, and the tests still pass, but I'm the first to admit that my testing of this has been light.

Example of the problem:

![Doubled backslashes](https://dl.dropbox.com/u/43048556/double-backslashes.png)
