### PR TITLE
Added lost xdebug version check for 'coverage_enable' option.

### DIFF
--- a/PHP/CodeCoverage/Driver/Xdebug.php
+++ b/PHP/CodeCoverage/Driver/Xdebug.php
@@ -65,11 +65,12 @@ class PHP_CodeCoverage_Driver_Xdebug implements PHP_CodeCoverage_Driver
         if (!extension_loaded('xdebug')) {
             throw new PHP_CodeCoverage_Exception('Xdebug is not loaded.');
         }
-
-        if (!ini_get('xdebug.coverage_enable')) {
-            throw new PHP_CodeCoverage_Exception(
-              'You need to set xdebug.coverage_enable=On in your php.ini.'
-            );
+        if (version_compare(phpversion('xdebug'), '2.2.0-dev', '>=')){
+            if (!ini_get('xdebug.coverage_enable')) {
+                throw new PHP_CodeCoverage_Exception(
+                    'You need to set xdebug.coverage_enable=On in your php.ini.'
+                );
+            }
         }
     }
 


### PR DESCRIPTION
If someone still using old xdebug extension then Code Coverage will not be available for him.
