### PR TITLE
Make class names unique

### DIFF
--- a/Tests/_files/NamespaceCoveredClass.php
+++ b/Tests/_files/NamespaceCoveredClass.php
@@ -1,7 +1,7 @@
 <?php
 namespace Foo;
 
-class CoveredParentClass
+class CoveredNamespaceParentClass
 {
     private function privateMethod()
     {
@@ -18,7 +18,7 @@ class CoveredParentClass
     }
 }
 
-class CoveredClass extends CoveredParentClass
+class CoveredNamespaceClass extends CoveredNamespaceParentClass
 {
     private function privateMethod()
     {

--- a/Tests/_files/source_with_namespace.php
+++ b/Tests/_files/source_with_namespace.php
@@ -2,16 +2,16 @@
 namespace bar\baz;
 
 /**
- * Represents foo.
+ * Represents foo_with_namespace.
  */
-class Foo
+class foo_with_namespace
 {
 }
 
 /**
  * @param mixed $bar
  */
-function &foo($bar)
+function &foo_with_namespace($bar)
 {
     $baz = function() {};
     $a   = TRUE ? TRUE : FALSE;

--- a/Tests/_files/source_without_namespace.php
+++ b/Tests/_files/source_without_namespace.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Represents foo.
+ * Represents foo_without_namespace.
  */
-class Foo
+class foo_without_namespace
 {
 }
 
 /**
  * @param mixed $bar
  */
-function &foo($bar)
+function &foo_without_namespace($bar)
 {
     $baz = function() {};
     $a   = TRUE ? TRUE : FALSE;


### PR DESCRIPTION
We ran into a problem with our autoloader map. Non-unique classes are just a pain for no gain.
