### PR TITLE
Normalize PHAR path on Windows - Fixes #107

### DIFF
--- a/PHP/CodeCoverage/Report/Factory.php
+++ b/PHP/CodeCoverage/Report/Factory.php
@@ -231,6 +231,7 @@ class PHP_CodeCoverage_Report_Factory
             // strip phar:// prefixes
             if (strpos($paths[$i], 'phar://') === 0) {
                 $paths[$i] = substr($paths[$i], 7);
+                $paths[$i] = strtr($paths[$i], '/', DIRECTORY_SEPARATOR);
             }
             $paths[$i] = explode(DIRECTORY_SEPARATOR, $paths[$i]);
 


### PR DESCRIPTION
Windows has a different `DIRECTORY_SEPARATOR` than PHP's `phar://` which  
has `/`. Set it.

This fix is broken on systems that have a `DIRECTORY_SEPARATOR` that is 
larger than one byte. No assertion for this edge-case.

Fixes #107
