### PR TITLE
Reduce vertical white space

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/Template/css/style.css
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/Template/css/style.css
@@ -6,6 +6,16 @@ body {
  width: 600px;
 }
 
+.table td {
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
+
+.table-condensed td {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
 .table .progress {
  margin-bottom: inherit;
 }


### PR DESCRIPTION
There is too much white space with the new Twitter bootstrap.

This PR is intended to reduce the useless vertical whitespace:

Before: http://s16.postimage.org/n0hycoied/cc_before.png
After: http://s18.postimage.org/xl71mliq1/cc_after.png
