### PR TITLE
Make source_with_oneline_annotations.php valid PHP

### DIFF
--- a/Tests/_files/source_with_oneline_annotations.php
+++ b/Tests/_files/source_with_oneline_annotations.php
@@ -1,7 +1,7 @@
 <?php
 
 /** Docblock */
-interface {
+interface Foo {
     public function bar();
 }
 


### PR DESCRIPTION
Currently `Tests/_files/source_with_oneline_annotations.php` isn't valid PHP since the interface is missing an identifier.

```
$ php -l Tests/_files/source_with_oneline_annotations.php 
PHP Parse error:  syntax error, unexpected '{', expecting identifier (T_STRING) in Tests/_files/source_with_oneline_annotations.php on line 4
```
