### PR TITLE
avoid file_get_contents error if file does not exist any more

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/File.php
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/File.php
@@ -424,6 +424,9 @@ class PHP_CodeCoverage_Report_HTML_Renderer_File extends PHP_CodeCoverage_Report
      */
     protected function loadFile($file)
     {
+        if (!file_exists($file)) {
+            return array();
+        }
         $buffer = file_get_contents($file);
         $lines  = explode("\n", str_replace("\t", '    ', $buffer));
         $result = array();


### PR DESCRIPTION
Our tests generate some PHP files which are executed and later deleted.
PHPCodeCoverage then fails with an error because it tries to open it with file_get_contents.
(The file is created in a directory that is in filter/blacklist but that does not seem to help, I did not investigate further).

The extra `file_exists` call may be too costly, I do not know if you will accept the change, but I will propose it just in case.
