### PR TITLE
Code Coverage report stops after anonymous function if last in class

### DIFF
--- a/PHP/CodeCoverage/Util.php
+++ b/PHP/CodeCoverage/Util.php
@@ -184,9 +184,11 @@ class PHP_CodeCoverage_Util
                                   $classes[$token->getName()]['methods']
                                 );
 
-                                $lastMethod = array_pop(
-                                  $classes[$token->getName()]['methods']
-                                );
+                                do {
+                                    $lastMethod = array_pop(
+                                      $classes[$token->getName()]['methods']
+                                    );
+                                } while ($lastMethod !== NULL && substr($lastMethod['signature'], 0, 18) == 'anonymous function');
 
                                 if ($lastMethod === NULL) {
                                     $lastMethod = $firstMethod;

--- a/Tests/PHP/CodeCoverage/FilterTest.php
+++ b/Tests/PHP/CodeCoverage/FilterTest.php
@@ -109,6 +109,7 @@ class PHP_CodeCoverage_FilterTest extends PHPUnit_Framework_TestCase
           TEST_FILES_PATH . 'NamespaceCoveragePublicTest.php',
           TEST_FILES_PATH . 'NamespaceCoveredClass.php',
           TEST_FILES_PATH . 'NotExistingCoveredElementTest.php',
+          TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php',
           TEST_FILES_PATH . 'source_with_ignore.php',
           TEST_FILES_PATH . 'source_with_namespace.php',
           TEST_FILES_PATH . 'source_with_oneline_annotations.php',

--- a/Tests/PHP/CodeCoverage/Report/CloverTest.php
+++ b/Tests/PHP/CodeCoverage/Report/CloverTest.php
@@ -93,4 +93,17 @@ class PHP_CodeCoverage_Report_CloverTest extends PHP_CodeCoverage_TestCase
           $clover->process($this->getCoverageForFileWithIgnoredLines())
         );
     }
+
+    /**
+     * @covers PHP_CodeCoverage_Report_Clover
+     */
+    public function testCloverForClassWithAnonymousFunction()
+    {
+        $clover = new PHP_CodeCoverage_Report_Clover;
+
+        $this->assertStringMatchesFormatFile(
+          TEST_FILES_PATH . 'class-with-anonymous-function-clover.xml',
+          $clover->process($this->getCoverageForClassWithAnonymousFunction())
+        );
+    }
 }

--- a/Tests/PHP/CodeCoverage/UtilTest.php
+++ b/Tests/PHP/CodeCoverage/UtilTest.php
@@ -159,6 +159,25 @@ class PHP_CodeCoverage_UtilTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetLinesToBeIgnored3()
+    {
+        $this->assertEquals(
+          array(
+            1 => TRUE,
+            2 => TRUE,
+            8 => TRUE,
+            15 => TRUE,
+            3 => TRUE,
+            4 => TRUE,
+            19 => TRUE,
+            16 => TRUE
+          ),
+          PHP_CodeCoverage_Util::getLinesToBeIgnored(
+            TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php'
+          )
+        );
+    }
+
     /**
      * @covers PHP_CodeCoverage_Util::getLinesToBeIgnored
      */

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -263,4 +263,41 @@ abstract class PHP_CodeCoverage_TestCase extends PHPUnit_Framework_TestCase
 
         return $stub;
     }
+
+    protected function getCoverageForClassWithAnonymousFunction()
+    {
+        $coverage = new PHP_CodeCoverage(
+          $this->setUpXdebugStubForClassWithAnonymousFunction(),
+          new PHP_CodeCoverage_Filter
+        );
+
+        $coverage->start('ClassWithAnonymousFunction', TRUE);
+        $coverage->stop();
+
+        return $coverage;
+    }
+
+    protected function setUpXdebugStubForClassWithAnonymousFunction()
+    {
+        $stub = $this->getMock('PHP_CodeCoverage_Driver_Xdebug');
+        $stub->expects($this->any())
+             ->method('stop')
+             ->will($this->returnValue(
+               array(
+                 TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php' => array(
+                    7  => 1,
+                    9  => 1,
+                    10 => -1,
+                    11 => 1,
+                    12 => 1,
+                    13 => 1,
+                    14 => 1,
+                    17 => 1,
+                    18 => 1
+                 )
+               )
+            ));
+
+        return $stub;
+    }
 }

--- a/Tests/_files/class-with-anonymous-function-clover.xml
+++ b/Tests/_files/class-with-anonymous-function-clover.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="%i">
+  <project timestamp="%i">
+    <file name="%s/source_with_class_and_anonymous_function.php">
+      <class name="CoveredClassWithAnonymousFunctionInStaticMethod" namespace="global">
+        <metrics methods="2" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="12" coveredstatements="11" elements="14" coveredelements="13"/>
+      </class>
+      <line num="5" type="method" name="runAnonymous" crap="1.04" count="1"/>
+      <line num="7" type="stmt" count="1"/>
+      <line num="9" type="stmt" count="1"/>
+      <line num="10" type="stmt" count="0"/>
+      <line num="11" type="method" name="anonymous function" crap="1" count="1"/>
+      <line num="12" type="stmt" count="1"/>
+      <line num="13" type="stmt" count="1"/>
+      <line num="14" type="stmt" count="1"/>
+      <line num="17" type="stmt" count="1"/>
+      <line num="18" type="stmt" count="1"/>
+      <metrics loc="19" ncloc="17" classes="1" methods="2" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="9" coveredstatements="8" elements="11" coveredelements="9"/>
+    </file>
+    <metrics files="1" loc="19" ncloc="17" classes="1" methods="2" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="9" coveredstatements="8" elements="11" coveredelements="9"/>
+  </project>
+</coverage>

--- a/Tests/_files/source_with_class_and_anonymous_function.php
+++ b/Tests/_files/source_with_class_and_anonymous_function.php
@@ -1,0 +1,19 @@
+<?php
+
+class CoveredClassWithAnonymousFunctionInStaticMethod
+{
+    public static function runAnonymous()
+    {
+        $filter = array('abc124', 'abc123', '123');
+
+        array_walk(
+            $filter,
+            function (&$val, $key) {
+                $val = preg_replace('|[^0-9]|', '', $val);
+            }
+        );
+
+        // Should be covered
+        $extravar = true;
+    }
+}


### PR DESCRIPTION
There is an existing issue for this: #152

And some more discussion about it from the PHP_TokenStream project: https://github.com/sebastianbergmann/php-token-stream/pull/28#issuecomment-11541021

The fix used here comes from that comment from @edorian.  Spent a good chunk of the day tracking down where the issue was, creating a couple of different tests to help dig.

Ultimately the Clover test I added is probably unnecessary, since the root of the problem ended up being in PHP_CodeCoverage_Util::getLinesToBeIgnored (which I also created a test for).  I left the clover test in place though.
