### PR TITLE
Change <acronym> tag to <abbr> in HTML report

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/File.php
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/File.php
@@ -148,7 +148,7 @@ class PHP_CodeCoverage_Report_HTML_Renderer_File extends PHP_CodeCoverage_Report
             'testedMethodsPercentAsString' => $node->getTestedMethodsPercent(),
             'testedClassesPercent'         => $node->getTestedClassesAndTraitsPercent(FALSE),
             'testedClassesPercentAsString' => $node->getTestedClassesAndTraitsPercent(),
-            'crap'                         => '<acronym title="Change Risk Anti-Patterns (CRAP) Index">CRAP</acronym>'
+            'crap'                         => '<abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr>'
           )
         );
 


### PR DESCRIPTION
The <acronym> tag is not supported in HTML5.
http://www.w3schools.com/tags/tag_acronym.asp
