### PR TITLE
Added ability to export PHP_CodeCoverage object to .smart format

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -794,4 +794,14 @@ class PHP_CodeCoverage
 
         return $this->ignoredLines[$filename];
     }
+
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function setTests(array $tests)
+    {
+        $this->tests = $tests;
+    }
 }

--- a/PHP/CodeCoverage/Autoload.php
+++ b/PHP/CodeCoverage/Autoload.php
@@ -79,6 +79,7 @@ spl_autoload_register(
             'php_codecoverage_report_node_file' => '/CodeCoverage/Report/Node/File.php',
             'php_codecoverage_report_node_iterator' => '/CodeCoverage/Report/Node/Iterator.php',
             'php_codecoverage_report_php' => '/CodeCoverage/Report/PHP.php',
+            'php_codecoverage_report_phpsmart' => '/CodeCoverage/Report/PHPSmart.php',
             'php_codecoverage_report_text' => '/CodeCoverage/Report/Text.php',
             'php_codecoverage_report_xml' => '/CodeCoverage/Report/XML.php',
             'php_codecoverage_report_xml_directory' => '/CodeCoverage/Report/XML/Directory.php',

--- a/PHP/CodeCoverage/Filter.php
+++ b/PHP/CodeCoverage/Filter.php
@@ -347,4 +347,24 @@ class PHP_CodeCoverage_Filter
 
         $this->addDirectoryToBlacklist($directory);
     }
+
+    public function getBlacklistedFiles()
+    {
+        return $this->blacklistedFiles;
+    }
+
+    public function setBlacklistedFiles($blacklistedFiles)
+    {
+        $this->blacklistedFiles = $blacklistedFiles;
+    }
+
+    public function getWhitelistedFiles()
+    {
+        return $this->whitelistedFiles;
+    }
+
+    public function setWhitelistedFiles($whitelistedFiles)
+    {
+        $this->whitelistedFiles = $whitelistedFiles;
+    }
 }

--- a/PHP/CodeCoverage/Report/PHPSmart.php
+++ b/PHP/CodeCoverage/Report/PHPSmart.php
@@ -1,0 +1,24 @@
+<?php
+class PHP_CodeCoverage_Report_PHPSmart
+{
+    /**
+     * @param  PHP_CodeCoverage $coverage
+     * @param  string           $target
+     * @return string
+     */
+    public function process(PHP_CodeCoverage $coverage, $target = NULL)
+    {
+        $output = '<?php $filter = new PHP_CodeCoverage_Filter();'
+            . '$filter->setBlacklistedFiles(' . var_export($coverage->filter()->getBlacklistedFiles(), 1) . ');'
+            . '$filter->setWhitelistedFiles(' . var_export($coverage->filter()->getWhitelistedFiles(), 1) . ');'
+            . '$object = new PHP_CodeCoverage(new PHP_CodeCoverage_Driver_Xdebug(), $filter); $object->setData('
+            . var_export($coverage->getData(), 1) . '); $object->setTests('
+            . var_export($coverage->getTests(), 1) . '); return $object;';
+
+        if ($target !== NULL) {
+            return file_put_contents($target, $output);
+        } else {
+            return $output;
+        }
+    }
+}

--- a/Tests/_files/CoverageClassExtendedTest.php
+++ b/Tests/_files/CoverageClassExtendedTest.php
@@ -1,4 +1,5 @@
 <?php
+include_once('CoveredClass.php');
 class CoverageClassExtendedTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/Tests/_files/CoverageFunctionParenthesesTest.php
+++ b/Tests/_files/CoverageFunctionParenthesesTest.php
@@ -1,4 +1,5 @@
 <?php
+include_once('CoveredFunction.php');
 class CoverageFunctionParenthesesTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/Tests/_files/NamespaceCoverageClassExtendedTest.php
+++ b/Tests/_files/NamespaceCoverageClassExtendedTest.php
@@ -1,4 +1,5 @@
 <?php
+include_once('NamespaceCoveredClass.php');
 class NamespaceCoverageClassExtendedTest extends PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
Export and import for PHP_CodeCoverage in our project was too long - approx 70 hours. With changing serialize/unserialize approach we've got 2.5 hours. New approach is var_export and include.
