### PR TITLE
Using var_export instead of serialize for PHP_CodeCoverage object export

### DIFF
--- a/PHP/CodeCoverage.php
+++ b/PHP/CodeCoverage.php
@@ -794,4 +794,14 @@ class PHP_CodeCoverage
 
         return $this->ignoredLines[$filename];
     }
+
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function setTests(array $tests)
+    {
+        $this->tests = $tests;
+    }
 }

--- a/PHP/CodeCoverage/Filter.php
+++ b/PHP/CodeCoverage/Filter.php
@@ -347,4 +347,24 @@ class PHP_CodeCoverage_Filter
 
         $this->addDirectoryToBlacklist($directory);
     }
+
+    public function getBlacklistedFiles()
+    {
+        return $this->blacklistedFiles;
+    }
+
+    public function setBlacklistedFiles($blacklistedFiles)
+    {
+        $this->blacklistedFiles = $blacklistedFiles;
+    }
+
+    public function getWhitelistedFiles()
+    {
+        return $this->whitelistedFiles;
+    }
+
+    public function setWhitelistedFiles($whitelistedFiles)
+    {
+        $this->whitelistedFiles = $whitelistedFiles;
+    }
 }

--- a/PHP/CodeCoverage/Report/PHP.php
+++ b/PHP/CodeCoverage/Report/PHP.php
@@ -44,11 +44,11 @@
  */
 
 /**
- * Uses serialize() to write a PHP_CodeCoverage object to a file.
+ * Uses var_export() to write a PHP_CodeCoverage object to a file.
  *
  * @category   PHP
  * @package    CodeCoverage
- * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     uyga <iamuyga@gmail.com>
  * @copyright  2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://github.com/sebastianbergmann/php-code-coverage
@@ -63,12 +63,17 @@ class PHP_CodeCoverage_Report_PHP
      */
     public function process(PHP_CodeCoverage $coverage, $target = NULL)
     {
-        $coverage = serialize($coverage);
+        $output = '<?php $filter = new PHP_CodeCoverage_Filter();'
+            . '$filter->setBlacklistedFiles(' . var_export($coverage->filter()->getBlacklistedFiles(), 1) . ');'
+            . '$filter->setWhitelistedFiles(' . var_export($coverage->filter()->getWhitelistedFiles(), 1) . ');'
+            . '$object = new PHP_CodeCoverage(new PHP_CodeCoverage_Driver_Xdebug(), $filter); $object->setData('
+            . var_export($coverage->getData(), 1) . '); $object->setTests('
+            . var_export($coverage->getTests(), 1) . '); return $object;';
 
         if ($target !== NULL) {
-            return file_put_contents($target, $coverage);
+            return file_put_contents($target, $output);
         } else {
-            return $coverage;
+            return $output;
         }
     }
 }

--- a/Tests/_files/CoverageClassExtendedTest.php
+++ b/Tests/_files/CoverageClassExtendedTest.php
@@ -1,4 +1,5 @@
 <?php
+include_once('CoveredClass.php');
 class CoverageClassExtendedTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/Tests/_files/CoverageFunctionParenthesesTest.php
+++ b/Tests/_files/CoverageFunctionParenthesesTest.php
@@ -1,4 +1,5 @@
 <?php
+include_once('CoveredFunction.php');
 class CoverageFunctionParenthesesTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/Tests/_files/NamespaceCoverageClassExtendedTest.php
+++ b/Tests/_files/NamespaceCoverageClassExtendedTest.php
@@ -1,4 +1,5 @@
 <?php
+include_once('NamespaceCoveredClass.php');
 class NamespaceCoverageClassExtendedTest extends PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
Export and import for PHP_CodeCoverage in our project was too long - approx 70 hours. With changing serialize/unserialize approach we've got 2.5 hours. New approach is var_export and include.
