### PR TITLE
Added definitions for T_CALLABLE, T_INSTEADOF, and T_TRAIT

### DIFF
--- a/PHP/CodeCoverage/Report/HTML/Renderer/File.php
+++ b/PHP/CodeCoverage/Report/HTML/Renderer/File.php
@@ -44,13 +44,13 @@
  */
 
 if (!defined('T_CALLABLE')) {
-	define('T_CALLABLE', 'undefined');
+    define('T_CALLABLE', 'undefined');
 }
 if (!defined('T_INSTEADOF')) {
-	define('T_INSTEADOF', 'undefined');
+    define('T_INSTEADOF', 'undefined');
 }
 if (!defined('T_TRAIT')) {
-	define('T_TRAIT', 'undefined');
+    define('T_TRAIT', 'undefined');
 }
 
 /**


### PR DESCRIPTION
This is needed to make the HTML FIle Renderer work with PHP 5.3
