### PR TITLE
Refactor File Coverage XML Report to use XMLWriter

### DIFF
--- a/PHP/CodeCoverage/Report/XML.php
+++ b/PHP/CodeCoverage/Report/XML.php
@@ -166,6 +166,7 @@ class PHP_CodeCoverage_Report_XML
             foreach ($tests as $test) {
                 $coverage->addTest($test);
             }
+            $coverage->finalize();
         }
 
         $this->initTargetDirectory(

--- a/PHP/CodeCoverage/Report/XML/File/Coverage.php
+++ b/PHP/CodeCoverage/Report/XML/File/Coverage.php
@@ -54,31 +54,56 @@
  */
 class PHP_CodeCoverage_Report_XML_File_Coverage
 {
+
+    /**
+     * @var XMLWriter
+     */
+    private $writer;
+
     /**
      * @var DOMElement
      */
     private $contextNode;
 
+    /**
+     * @var bool
+     */
+    private $finalized = false;
+
+
     public function __construct(DOMElement $context, $line)
     {
         $this->contextNode = $context;
 
-        $this->setLine($line);
-    }
-
-    private function setLine($line)
-    {
-        $this->contextNode->setAttribute('nr', $line);
+        $this->writer = new XMLWriter();
+        $this->writer->openMemory();
+        $this->writer->startElementNs(null, $context->nodeName, 'http://schema.phpunit.de/coverage/1.0');
+        $this->writer->writeAttribute('nr', $line);
     }
 
     public function addTest($test)
     {
-        $covered = $this->contextNode->appendChild(
-          $this->contextNode->ownerDocument->createElementNS(
-            'http://schema.phpunit.de/coverage/1.0', 'covered'
-          )
+        if ($this->finalized) {
+            throw new PHP_CodeCoverage_Exception('Coverage Report already finalized');
+        }
+
+        $this->writer->startElement('covered');
+        $this->writer->writeAttribute('by', $test);
+        $this->writer->endElement();
+    }
+
+    public function finalize()
+    {
+        $this->writer->endElement();
+
+        $fragment = $this->contextNode->ownerDocument->createDocumentFragment();
+        $fragment->appendXML($this->writer->outputMemory());
+
+        $this->contextNode->parentNode->replaceChild(
+            $fragment,
+            $this->contextNode
         );
 
-        $covered->setAttribute('by', $test);
+        $this->finalized = true;
     }
 }


### PR DESCRIPTION
This should mitigate DOM related performance issues when generating coverage reports with many tests covering the same lines.
