### PR TITLE
Text report was using an undefined attribute to render the summary (only when the option "showOnlySummary" was marked as true)

### DIFF
--- a/PHP/CodeCoverage/Report/Text.php
+++ b/PHP/CodeCoverage/Report/Text.php
@@ -173,7 +173,7 @@ class PHP_CodeCoverage_Report_Text
         $output .= $this->format($colors['lines'], $padding, $lines);
 
         if ($this->showOnlySummary) {
-            return $this->outputStream->write($output . PHP_EOL);
+            return $output . PHP_EOL;
         }
 
         $classCoverage = array();


### PR DESCRIPTION
I believe that this class was refactored or the `$this->outputStream` was copied from another class and has been forgotten.

That was raising warnings and errors, because `outputStream` attribute does not exists.
