### PR TITLE
Fix abstract methods coverage count in output

### DIFF
--- a/PHP/CodeCoverage/Report/Clover.php
+++ b/PHP/CodeCoverage/Report/Clover.php
@@ -146,7 +146,7 @@ class PHP_CodeCoverage_Report_Clover
                         }
                     }
 
-                    if ($methodCount > 0) {
+                    if ($method['executedLines'] == $method['executableLines']) {
                         $coveredMethods++;
                     }
 

--- a/PHP/CodeCoverage/Report/Text.php
+++ b/PHP/CodeCoverage/Report/Text.php
@@ -193,7 +193,7 @@ class PHP_CodeCoverage_Report_Text
                         }
                     }
 
-                    if ($methodCount > 0) {
+                    if ($method['executedLines'] == $method['executableLines']) {
                         $coveredMethods++;
                     }
 


### PR DESCRIPTION
Fix `coverage-text` and  `coverage-clover` to count the abstract methods as covered.

Changes based on how covered methods counted in `coverage-html`.

Fix for issue #96.

TL;DR

I noted that in this build https://travis-ci.org/pinepain/amqpy/builds/17570704 (others too), some methods reported as not covered, while html output gives correct output.

![screen shot 2014-01-24 at 11 27 26 pm](https://f.cloud.github.com/assets/2185793/2000153/6e71ca8e-8552-11e3-940b-11c22fa97569.png)
![screen shot 2014-01-24 at 11 28 05 pm](https://f.cloud.github.com/assets/2185793/2000155/705f9ace-8552-11e3-975d-96479b9b460d.png)
