### PR TITLE
Suppressing warnings when running exec.

### DIFF
--- a/PHP/CodeCoverage/Version.php
+++ b/PHP/CodeCoverage/Version.php
@@ -72,7 +72,7 @@ class PHP_CodeCoverage_Version
             if (is_dir(dirname(dirname(__DIR__)) . '/.git')) {
                 $dir = getcwd();
                 chdir(__DIR__);
-                $version = exec('git describe --tags');
+                $version = @exec('git describe --tags');
                 chdir($dir);
 
                 if ($version) {


### PR DESCRIPTION
Fixes: Generating code coverage report in HTML format ...PHP Warning:  exec(): Unable to fork [git describe --tags] in /var/www/vendor/phpunit/php-code-coverage/PHP/CodeCoverage/Version.php on line 76
