### PR TITLE
Fixed not working codecoverage under windows

### DIFF
--- a/PHP/CodeCoverage/Report/Node.php
+++ b/PHP/CodeCoverage/Report/Node.php
@@ -135,7 +135,9 @@ abstract class PHP_CodeCoverage_Report_Node implements Countable
     public function getPath()
     {
         if ($this->path === NULL) {
-            if ($this->parent === NULL) {
+           if ($this->parent === NULL ||
+               $this->parent->getPath() == NULL
+                   ) {
                 $this->path = $this->name;
             } else {
                 $this->path = $this->parent->getPath() . '/' . $this->name;


### PR DESCRIPTION
Somehow the fix from https://github.com/geissler/php-code-coverage/commit/a529463ebdca58872c71b1a19b9470efc5c376f6
