### PR TITLE
hhvm code coverage fix. Lines to be ignored process existing files

### DIFF
--- a/src/CodeCoverage/Parser.php
+++ b/src/CodeCoverage/Parser.php
@@ -127,7 +127,7 @@ class PHP_CodeCoverage_Parser
             $this->ignoredLines[$filename] = array();
             $ignore                        = false;
             $stop                          = false;
-            $lines                         = file($filename);
+            $lines                         = file_exists($filename) ? file($filename) : array();
             $numLines                      = count($lines);
 
             foreach ($lines as $index => $line) {


### PR DESCRIPTION
running phpunit with code coverage in hhvm environment was trying to load file('systemlib.php.reflection-internals-functions') that dose not exist resulting in error: 

``` sh
HipHop Fatal error: Uncaught exception 'PHPUnit_Framework_Error_Warning' with message 'No such file or directory' in vendor/phpunit/php-code-coverage/src/CodeCoverage/Parser.php:130
Stack trace:
#0 (): PHPUnit_Util_ErrorHandler::handleError()
#1 vendor/phpunit/php-code-coverage/src/CodeCoverage/Parser.php(130): file()
#2 vendor/phpunit/php-code-coverage/src/CodeCoverage/Driver.php(148): PHP_CodeCoverage_Parser->getLinesToBeIgnored()
#3 vendor/phpunit/php-code-coverage/src/CodeCoverage/Driver.php(103): PHP_CodeCoverage_Driver->filter()
#4 vendor/phpunit/php-code-coverage/src/CodeCoverage.php(291): PHP_CodeCoverage_Driver->stop()
#5 vendor/phpunit/phpunit/src/Framework/TestResult.php(733): PHP_CodeCoverage->stop()
#6 vendor/phpunit/phpunit/src/Framework/TestCase.php(755): PHPUnit_Framework_TestResult->run()
#7 vendor/phpunit/phpunit/src/Framework/TestSuite.php(675): PHPUnit_Framework_TestCase->run()
#8 vendor/phpunit/phpunit/src/Framework/TestSuite.php(675): PHPUnit_Framework_TestSuite->run()
#9 vendor/phpunit/phpunit/src/Framework/TestSuite.php(675): PHPUnit_Framework_TestSuite->run()
#10 vendor/phpunit/phpunit/src/TextUI/TestRunner.php(427): PHPUnit_Framework_TestSuite->run()
#11 vendor/phpunit/phpunit/src/TextUI/Command.php(186): PHPUnit_TextUI_TestRunner->doRun()
#12 vendor/phpunit/phpunit/src/TextUI/Command.php(138): PHPUnit_TextUI_Command->run()
#13 vendor/phpunit/phpunit/phpunit(55): PHPUnit_TextUI_Command::main()
#14 {main}
```

This commit is checking if file exist before reading lines from it. If file is missing, then return empty array so process will not stop.
