### PR TITLE
Add version limit for token stream to avoid incompatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=5.3.3",
         "phpunit/php-file-iterator": ">=1.3.0@stable",
-        "phpunit/php-token-stream": ">=1.1.3@stable",
+        "phpunit/php-token-stream": ">=1.1.3,<1.3.0@stable",
         "phpunit/php-text-template": ">=1.2.0@stable"
     },
     "require-dev": {


### PR DESCRIPTION
The changes to file structure in php-token-stream's 1.3.0 cause a failure to load its removed Autoload.php in php-code-coverage's version 1.2, ultimately breaking PHPUnit 3.7.
