### PR TITLE
Fix installation instructions for stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 ## Installation
 
-To add PHP_CodeCoverage as a local, per-project dependency to your project, simply add a dependency on `phpunit/php-code-coverage` to your project's `composer.json` file. Here is a minimal example of a `composer.json` file that just defines a dependency on PHP_CodeCoverage 3.0:
+To add PHP_CodeCoverage as a local, per-project dependency to your project, simply add a dependency on `phpunit/php-code-coverage` to your project's `composer.json` file. Here is a minimal example of a `composer.json` file that just defines a dependency on PHP_CodeCoverage 2.0:
 
     {
-        "require": {
-            "phpunit/php-code-coverage": "3.0.*"
+        "require-dev": {
+            "phpunit/php-code-coverage": "2.0.*"
         }
     }
 


### PR DESCRIPTION
Composer uses "stable" as default stability. so switch project to that to avoid surprises.
Also move PHP_CodeCoverage to "require-dev" section, same as PHPUnit.
