### PR TITLE
Make test cases covering each line unique

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -322,7 +322,9 @@ class PHP_CodeCoverage
 
             foreach ($lines as $k => $v) {
                 if ($v == 1) {
-                    $this->data[$file][$k][] = $id;
+                    if (empty($this->data[$file][$k]) || !in_array($id, $this->data[$file][$k])) {
+                        $this->data[$file][$k][] = $id;
+                    }
                 }
             }
         }


### PR DESCRIPTION
merge() function uses array_unique(), here it was forgotten. The coverage object was growing out of bounds.