### PR TITLE
Align lower/upper bound for coverage percentage interpretation in text and HTML report

### DIFF
--- a/src/CodeCoverage/Report/HTML/Renderer.php
+++ b/src/CodeCoverage/Report/HTML/Renderer.php
@@ -259,9 +259,9 @@ abstract class PHP_CodeCoverage_Report_HTML_Renderer
      */
     protected function getColorLevel($percent)
     {
-        if ($percent < $this->lowUpperBound) {
+        if ($percent <= $this->lowUpperBound) {
             return 'danger';
-        } elseif ($percent >= $this->lowUpperBound &&
+        } elseif ($percent > $this->lowUpperBound &&
             $percent <  $this->highLowerBound) {
             return 'warning';
         } else {

--- a/src/CodeCoverage/Report/Text.php
+++ b/src/CodeCoverage/Report/Text.php
@@ -219,7 +219,7 @@ class PHP_CodeCoverage_Report_Text
             $numberOfCoveredElements, $totalNumberOfElements
         );
 
-        if ($coverage > $this->highLowerBound) {
+        if ($coverage >= $this->highLowerBound) {
             return $this->colors['green'];
         } elseif ($coverage > $this->lowUpperBound) {
             return $this->colors['yellow'];


### PR DESCRIPTION
Aligned lower/upper bound for coverage percentage interpretation for text in HTML report (according to https://phpunit.de/manual/4.5/en/appendixes.configuration.html).