### PR TITLE
Fix for HHVM code coverage to bring the it close to real #302

### DIFF
--- a/src/CodeCoverage/Driver/HHVM.php
+++ b/src/CodeCoverage/Driver/HHVM.php
@@ -51,6 +51,47 @@ class PHP_CodeCoverage_Driver_HHVM implements PHP_CodeCoverage_Driver
 
         fb_disable_code_coverage();
 
-        return $codeCoverage;
+        return $this->expandCoverage($codeCoverage);
+    }
+
+    /**
+     * @param  array $data
+     * @return array
+     */
+    private function expandCoverage(array $data)
+    {
+        $coverages = [];
+        foreach($data as $file => $lines) {
+            $num = array_keys($lines);
+            foreach(range(0, $this->getNumberOfLinesInFile($file)) as $l) {
+                if(isset($lines[$l])) {
+                    $lines[$l] = 1;
+                } else {
+                    $lines[$l] = -1;
+                }
+            }
+            ksort($lines);
+            $coverages[$file] = $lines;
+        }
+        return $coverages;
+    }
+
+    /**
+     * @param  string $file
+     * @return integer
+     */
+    private function getNumberOfLinesInFile($file)
+    {
+        if (!file_exists($file)) {
+            return 0;
+        }
+        $buffer = file_get_contents($file);
+        $lines  = substr_count($buffer, "\n");
+
+        if (substr($buffer, -1) !== "\n") {
+            $lines++;
+        }
+
+        return $lines;
     }
 }


### PR DESCRIPTION
fb_get_code_coverage returns the number of time that a line in a file
was executed which is totaly different what standard xdebug
implementation is. This patch bring the number of executed lines close
to what is supposed to be.