### PR TITLE
glyphicons-halflings-regular.woff2 wasn't created

### DIFF
--- a/src/CodeCoverage/Report/HTML.php
+++ b/src/CodeCoverage/Report/HTML.php
@@ -147,6 +147,7 @@ class PHP_CodeCoverage_Report_HTML
         copy($this->templatePath . 'fonts/glyphicons-halflings-regular.svg', $dir . 'glyphicons-halflings-regular.svg');
         copy($this->templatePath . 'fonts/glyphicons-halflings-regular.ttf', $dir . 'glyphicons-halflings-regular.ttf');
         copy($this->templatePath . 'fonts/glyphicons-halflings-regular.woff', $dir . 'glyphicons-halflings-regular.woff');
+        copy($this->templatePath . 'fonts/glyphicons-halflings-regular.woff2', $dir . 'glyphicons-halflings-regular.woff2');
 
         $dir = $this->getDirectory($target . 'js');
         copy($this->templatePath . 'js/bootstrap.min.js', $dir . 'bootstrap.min.js');


### PR DESCRIPTION
The `glyphicons-halflings-regular.woff2` font for the HTML reporter wasn't being copied over to the reports directory, resulting in Bootstrap failing to load that font.