### PR TITLE
Fix Node::getPath() on Windows when files are on two logical disks

### DIFF
--- a/src/CodeCoverage/Report/Node.php
+++ b/src/CodeCoverage/Report/Node.php
@@ -100,7 +100,7 @@ abstract class PHP_CodeCoverage_Report_Node implements Countable
     public function getPath()
     {
         if ($this->path === null) {
-            if ($this->parent === null || $this->parent->getPath() === null) {
+            if ($this->parent === null || $this->parent->getPath() === null || $this->parent->getPath() === false) {
                 $this->path = $this->name;
             } else {
                 $this->path = $this->parent->getPath() . '/' . $this->name;


### PR DESCRIPTION
On my Windows Jenkins build server, I have PHP on the `C:\` drive and the code I'm testing phpunit with on `E:\`.

The unit tests are running fine, but the Clover and Crap4j reports are empty.  The skeleton XML is there, but no files are listed.

I've found that something has changed since the fixes for https://github.com/sebastianbergmann/php-code-coverage/issues/93 and https://github.com/sebastianbergmann/php-code-coverage/pull/106 went in that addressed this very problem.  After `reducePaths()` runs, the common root node's name (of `C:\` and `E:\`) is now `false` instead of `null` as the previous address checked.

Checking for `false` in addition to `null` fixes this issue.