### PR TITLE
Adds SebastianBergmann\GlobalState to Filter.php (updates blacklist)

### DIFF
--- a/src/CodeCoverage/Filter.php
+++ b/src/CodeCoverage/Filter.php
@@ -63,6 +63,9 @@ class PHP_CodeCoverage_Filter
         'SebastianBergmann\Comparator\Comparator' => 1,
         'SebastianBergmann\Exporter\Exporter' => 1,
         'SebastianBergmann\RecursionContext\Context' => 1,
+        'SebastianBergmann\GlobalState\Restorer'  => 1,
+        'SebastianBergmann\GlobalState\Snapshot'  => 1,
+        'SebastianBergmann\GlobalState\Blacklist' => 1,
         'SebastianBergmann\Version' => 1,
         'Composer\Autoload\ClassLoader' => 1,
         'Doctrine\Instantiator\Instantiator' => 1


### PR DESCRIPTION
Using these versions:

![screen 20shot 20on 202015-04-10 20at 2013 3a15 3a49](https://cloud.githubusercontent.com/assets/114275/7094034/d06a823a-df83-11e4-83dd-1e893667879b.png)

`\SebastianBergmann\GlobalState::Blacklist`, `\SebastianBergmann\GlobalState::Restorer`, `\SebastianBergmann\GlobalState::Snapshot` all appear in my coverage report.

![screen 20shot 202015-04-10 20at 2013 18 26](https://cloud.githubusercontent.com/assets/114275/7094072/2094f7cc-df84-11e4-976e-b408b08098b1.png)

I'm not installing it explicitly, so I'm assuming it's a PHPUnit dependency. However, according to the [PHPUnit Manual](https://phpunit.de/manual/current/en/code-coverage-analysis.html) these files should be excluded. 

>>>
By default, a blacklist is used to exclude files from the code coverage report. This blacklist is pre-filled with the source files of PHPUnit and its dependencies. 
>>>

Adding them here removed them from the coverage report.