### PR TITLE
Respect coverage data's own filter when merging another source

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -349,7 +349,7 @@ class PHP_CodeCoverage
     {
         foreach ($that->getData() as $file => $lines) {
             if (!isset($this->data[$file])) {
-                if (!$that->filter()->isFiltered($file)) {
+                if (!$that->filter()->isFiltered($file) && !$this->filter->isFiltered($file)) {
                     $this->data[$file] = $lines;
                 }
 

--- a/tests/PHP/CodeCoverageTest.php
+++ b/tests/PHP/CodeCoverageTest.php
@@ -318,6 +318,25 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
     }
 
     /**
+     * @covers PHP_CodeCoverage::getData
+     * @covers PHP_CodeCoverage::merge
+     */
+    public function testMergeRespectsTargetFilter()
+    {
+        $filter = new PHP_CodeCoverage_Filter;
+        $filter->addFileToWhitelist(TEST_FILES_PATH . 'BankAccount.php');
+
+        $coverage = $this->getCoverageForBankAccount($filter);
+
+        $coverage->merge($this->getCoverageForClassWithAnonymousFunction());
+
+        $this->assertEquals(
+            $this->getExpectedDataArrayForBankAccount(),
+            $coverage->getData()
+        );
+    }
+
+    /**
      * @covers PHP_CodeCoverage::getLinesToBeIgnored
      */
     public function testGetLinesToBeIgnored()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,7 +74,7 @@ abstract class PHP_CodeCoverage_TestCase extends PHPUnit_Framework_TestCase
         );
     }
 
-    protected function getCoverageForBankAccount()
+    protected function getCoverageForBankAccount(PHP_CodeCoverage_Filter $filter = null)
     {
         $data = $this->getXdebugDataForBankAccount();
 
@@ -88,7 +88,7 @@ abstract class PHP_CodeCoverage_TestCase extends PHPUnit_Framework_TestCase
                 $data[3]
             ));
 
-        $coverage = new PHP_CodeCoverage($stub, new PHP_CodeCoverage_Filter);
+        $coverage = new PHP_CodeCoverage($stub, $filter ?: new PHP_CodeCoverage_Filter);
 
         $coverage->start(
             new BankAccountTest('testBalanceIsInitiallyZero'),


### PR DESCRIPTION
My use case for this is that tests that are run with process isolation don't get the whitelist information passed through to the code coverage collector, so when that coverage information is merged back in to the master process, non-whitelisted files are often added. 

I guess that might be something you want to fix upstream, but I imagine that's a bit more of a difficult task, so thought I'd try my luck here first :)