### PR TITLE
Ignore xdebug://debug-eval for file check exists

### DIFF
--- a/src/CodeCoverage/Driver/Xdebug.php
+++ b/src/CodeCoverage/Driver/Xdebug.php
@@ -72,7 +72,7 @@ class PHP_CodeCoverage_Driver_Xdebug implements PHP_CodeCoverage_Driver
                 unset($data[$file][0]);
             }
 
-            if (file_exists($file)) {
+            if ($file != "xdebug://debug-eval" && file_exists($file)) {
                 $numLines = $this->getNumberOfLinesInFile($file);
 
                 foreach (array_keys($data[$file]) as $line) {


### PR DESCRIPTION
Ignore xdebug://debug-eval for file check exists

https://github.com/sebastianbergmann/php-code-coverage/issues/231#issuecomment-97994962