### PR TITLE
Significantly improve merge performance and fix false uncovered lines

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -349,7 +349,7 @@ class PHP_CodeCoverage
      */
     public function merge(PHP_CodeCoverage $that)
     {
-        foreach ($that->getData() as $file => $lines) {
+        foreach ($that->getData(true) as $file => $lines) {
             if (!isset($this->data[$file])) {
                 if (!$that->filter()->isFiltered($file)) {
                     $this->data[$file] = $lines;
@@ -372,6 +372,8 @@ class PHP_CodeCoverage
         }
 
         $this->tests = array_merge($this->tests, $that->getTests());
+        $this->filter->addFilesToBlacklist(array_keys($that->filter()->getBlacklistedFiles()));
+        $this->filter->addFilesToWhitelist(array_keys($that->filter()->getWhitelistedFiles()));
     }
 
     /**


### PR DESCRIPTION
Do not process uncovered files from whitelist while merging several php-coverage dumps and do it only when generating a report.

This also fixes false positive uncovered lines (like single curly brace on a line) for files which are not covered in each php-coverage dump.

Speedup when merging 38 php-coverage dumps is:
php report:  5m15.743s -> 0m1.844s = 171x
html report: 5m57.710s -> 0m23.524s = 15x