### PR TITLE
disable-code-coverage-ignore

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -81,6 +81,11 @@ class PHP_CodeCoverage
     private $ignoredLines = array();
 
     /**
+     * @var bool
+     */
+    private $disableIgnoredLines = false;
+
+    /**
      * Test data.
      *
      * @var array
@@ -481,6 +486,22 @@ class PHP_CodeCoverage
     }
 
     /**
+     * @param  boolean                    $flag
+     * @throws PHP_CodeCoverage_Exception
+     */
+    public function setDisableIgnoredLines($flag)
+    {
+        if (!is_bool($flag)) {
+            throw PHP_CodeCoverage_Util_InvalidArgumentHelper::factory(
+                1,
+                'boolean'
+            );
+        }
+
+        $this->disableIgnoredLines = $flag;
+    }
+
+    /**
      * Applies the @covers annotation filtering.
      *
      * @param  array                                                 $data
@@ -654,6 +675,11 @@ class PHP_CodeCoverage
             $stop                          = false;
             $lines                         = file($filename);
             $numLines                      = count($lines);
+
+            if ($this->disableIgnoredLines)
+            {
+                return $this->ignoredLines[$filename];
+            }
 
             foreach ($lines as $index => $line) {
                 if (!trim($line)) {

--- a/tests/PHP/CodeCoverageTest.php
+++ b/tests/PHP/CodeCoverageTest.php
@@ -34,6 +34,9 @@ require_once TEST_FILES_PATH . 'BankAccountTest.php';
  */
 class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
 {
+    /**
+     * @var PHP_CodeCoverage
+     */
     private $coverage;
 
     protected function setUp()
@@ -471,5 +474,21 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
         $getLinesToBeIgnored->setAccessible(true);
 
         return $getLinesToBeIgnored;
+    }
+
+    /**
+     * @covers PHP_CodeCoverage::getLinesToBeIgnored
+     */
+    public function testGetLinesToBeIgnoredWhenIgnoreIsDisabled()
+    {
+        $this->coverage->setDisableIgnoredLines(true);
+
+        $this->assertEquals(
+            array(),
+            $this->getLinesToBeIgnored()->invoke(
+                $this->coverage,
+                TEST_FILES_PATH . 'source_with_ignore.php'
+            )
+        );
     }
 }


### PR DESCRIPTION
added flag to code coverage class with a tested short circuit statement so that lines to ignore are not calculated regardless of the annotations in the source. by default the ignored lines will be calculated, just as they were before.

@sebastianbergmann i saw your presentations at php[tek] 2015 and thought this was a great idea. what do you think of my implementation? my next step would be to update the phpunit project to utilize this new flag.