### PR TITLE
Ignore encoding issues in htmlspecialchars()

### DIFF
--- a/src/CodeCoverage/Report/HTML/Renderer/File.php
+++ b/src/CodeCoverage/Report/HTML/Renderer/File.php
@@ -439,7 +439,7 @@ class PHP_CodeCoverage_Report_HTML_Renderer_File extends PHP_CodeCoverage_Report
             $value = str_replace(
                 array("\t", ' '),
                 array('&nbsp;&nbsp;&nbsp;&nbsp;', '&nbsp;'),
-                htmlspecialchars($value)
+                htmlspecialchars($value, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE)
             );
 
             if ($value === "\n") {


### PR DESCRIPTION
Fix #340 
In case file is not UTF-8 encoded, we want `htmlspecialchars()` not to return nothing.