### PR TITLE
Fix XML coverage report to honor the obviously new data type for $result

### DIFF
--- a/src/CodeCoverage/Report/XML/Tests.php
+++ b/src/CodeCoverage/Report/XML/Tests.php
@@ -35,7 +35,7 @@ class PHP_CodeCoverage_Report_XML_Tests
         $this->contextNode = $context;
     }
 
-    public function addTest($test, $result)
+    public function addTest($test, array $result)
     {
         $node = $this->contextNode->appendChild(
             $this->contextNode->ownerDocument->createElementNS(
@@ -44,8 +44,9 @@ class PHP_CodeCoverage_Report_XML_Tests
             )
         );
         $node->setAttribute('name', $test);
-        $node->setAttribute('result', (int) $result);
-        $node->setAttribute('status', $this->codeMap[(int) $result]);
+        $node->setAttribute('size', $result['size']);
+        $node->setAttribute('result', (int) $result['status']);
+        $node->setAttribute('status', $this->codeMap[(int) $result['status']]);
 
     }
 }


### PR DESCRIPTION
The current XML version of code coverage report is broken as due to the data type change for $result, all tests are considered skipped ( an (int) cast of an array returns 1 aka SKIPPED as soon as it's not empty).

This PR fixes that.