### PR TITLE
Restore compatibility with PHP 5.3

### DIFF
--- a/src/CodeCoverage/Report/HTML/Renderer/File.php
+++ b/src/CodeCoverage/Report/HTML/Renderer/File.php
@@ -69,7 +69,7 @@ class PHP_CodeCoverage_Report_HTML_Renderer_File extends PHP_CodeCoverage_Report
 
         $this->htmlspecialcharsFlags = ENT_COMPAT;
 
-        if (defined('ENT_SUBSTITUTE')) {
+        if (PHP_VERSION_ID >= 50400 && defined('ENT_SUBSTITUTE')) {
             $this->htmlspecialcharsFlags = $this->htmlspecialcharsFlags | ENT_HTML401 | ENT_SUBSTITUTE;
         }
     }


### PR DESCRIPTION
Since the 4.7.0 release of PHPUnit, the compatibility with PHP 5.3 is lost, even with https://github.com/sebastianbergmann/php-code-coverage/commit/c43ad52e723b6311f644eeab34b4beebb72012ee.

```
Notice: Use of undefined constant ENT_HTML401 - assumed 'ENT_HTML401' in phar:///usr/bin/phpunit/php-code-coverage/CodeCoverage/Report/HTML/Renderer/File.php on line 73

Call Stack:
    0.0009    1051096   1. {main}() /usr/bin/phpunit:0
    0.0978   24925672   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:537
    0.0978   24926712   3. PHPUnit_TextUI_Command->run() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:103
    0.6591   43908024   4. PHPUnit_TextUI_TestRunner->doRun() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:151
   34.9376  182439232   5. PHP_CodeCoverage_Report_HTML->process() phar:///usr/bin/phpunit/phpunit/TextUI/TestRunner.php:480
   38.1996  189975824   6. PHP_CodeCoverage_Report_HTML_Renderer_File->__construct() phar:///usr/rage/Report/HTML/Renderer/File.php on line 73
```

The problem is still on PHPUnit 4.7.2.

Even if the test in File.php seems to be ok. 

```
jenkins@JENKINS:~$ php -v
PHP 5.3.29-1~dotdeb.0 with Suhosin-Patch (cli) (built: Aug 14 2014 19:55:20)
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2014 Zend Technologies
    with Xdebug v2.2.5, Copyright (c) 2002-2014, by Derick Rethans

jenkins@JENKINS:~$ phpunit --version
PHPUnit 4.7.2 by Sebastian Bergmann and contributors.

jenkins@JENKINS:~$ php -r "var_dump(defined('ENT_SUBSTITUTE'));"
bool(false)
```

I think the problem come from [Twig](https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Extension/Core.php#L3-L6) (since we have Twig in our stack):

```php
if (!defined('ENT_SUBSTITUTE')) {
    // use 0 as hhvm does not support several flags yet
    define('ENT_SUBSTITUTE', 0);
}
```

So, instead of checking only if the constant is defined, I've added a check on the PHP version itself. Should be more accurate like that.