### PR TITLE
Omit unnecessary file read when `disableIgnoredLines` is set

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -676,10 +676,10 @@ class PHP_CodeCoverage
                 return $this->ignoredLines[$filename];
             }
 
-            $ignore                        = false;
-            $stop                          = false;
-            $lines                         = file($filename);
-            $numLines                      = count($lines);
+            $ignore   = false;
+            $stop     = false;
+            $lines    = file($filename);
+            $numLines = count($lines);
 
             foreach ($lines as $index => $line) {
                 if (!trim($line)) {

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -671,14 +671,15 @@ class PHP_CodeCoverage
 
         if (!isset($this->ignoredLines[$filename])) {
             $this->ignoredLines[$filename] = array();
-            $ignore                        = false;
-            $stop                          = false;
-            $lines                         = file($filename);
-            $numLines                      = count($lines);
 
             if ($this->disableIgnoredLines) {
                 return $this->ignoredLines[$filename];
             }
+
+            $ignore                        = false;
+            $stop                          = false;
+            $lines                         = file($filename);
+            $numLines                      = count($lines);
 
             foreach ($lines as $index => $line) {
                 if (!trim($line)) {


### PR DESCRIPTION
When `disableIgnoredLines` is set, the file is being read just to discard the data. This pull prevents this.