### PR TITLE
drop --dev switch in composer install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
     - 5.6
 
 before_script:
-    - COMPOSER_ROOT_VERSION=dev-master composer install --dev --prefer-source
+    - COMPOSER_ROOT_VERSION=dev-master composer install --prefer-source
 
 script: vendor/bin/phpunit --configuration ./build/travis-ci.xml
 


### PR DESCRIPTION
`--dev` packages are installed by default. This fixes a composer warning.