### PR TITLE
Added a phpdbg based code coverage driver.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpunit/php-file-iterator": "~1.3",
         "phpunit/php-token-stream": "~1.3",
         "phpunit/php-text-template": "~1.2",
-        "sebastian/environment": "~1.0",
+        "sebastian/environment": "dev-phpdbg_cc",
         "sebastian/version": "~1.0"
     },
     "require-dev": {
@@ -46,5 +46,12 @@
         "branch-alias": {
             "dev-master": "2.2.x-dev"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/staabm/environment"
+        }
+    ]
+    
 }

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -96,13 +96,17 @@ class PHP_CodeCoverage
     public function __construct(PHP_CodeCoverage_Driver $driver = null, PHP_CodeCoverage_Filter $filter = null)
     {
         if ($driver === null) {
-            $runtime = new Runtime;
+            if (PHP_SAPI === 'phpdbg') {
+                $driver = new PHP_CodeCoverage_Driver_Phpdbg;
+            } else {
+                $runtime = new Runtime;
 
-            if (!$runtime->hasXdebug()) {
-                throw new PHP_CodeCoverage_Exception('No code coverage driver available');
+                if (!$runtime->hasXdebug()) {
+                    throw new PHP_CodeCoverage_Exception('No code coverage driver available');
+                }
+
+                $driver = new PHP_CodeCoverage_Driver_Xdebug;
             }
-
-            $driver = new PHP_CodeCoverage_Driver_Xdebug;
         }
 
         if ($filter === null) {

--- a/src/CodeCoverage/Driver.php
+++ b/src/CodeCoverage/Driver.php
@@ -15,6 +15,12 @@
  */
 interface PHP_CodeCoverage_Driver
 {
+    // const values map to the defaults provided by xdebug-code-coverage
+    // see http://xdebug.org/docs/code_coverage
+    const LINE_EXECUTED = 1;
+    const LINE_NOT_EXECUTED = -1;
+    const LINE_NOT_EXECUTABLE = -2;
+
     /**
      * Start collection of code coverage information.
      */

--- a/src/CodeCoverage/Driver/Phpdbg.php
+++ b/src/CodeCoverage/Driver/Phpdbg.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * This file is part of the PHP_CodeCoverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Driver for Phpdbg's code coverage functionality.
+ *
+ * @since Class available since Release 2.2.0
+ * @codeCoverageIgnore
+ */
+class PHP_CodeCoverage_Driver_Phpdbg implements PHP_CodeCoverage_Driver
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        if (PHP_SAPI !== 'phpdbg') {
+            throw new PHP_CodeCoverage_Exception('This driver requires the phpdbg sapi');
+        }
+
+        if (version_compare(phpversion(), '7.0', '<')) {
+            // actually we require the phpdbg version shipped with php7, not php7 itself
+            throw new PHP_CodeCoverage_Exception(
+                'phpdbg based code coverage requires at least php7'
+            );
+        }
+    }
+
+    /**
+     * Start collection of code coverage information.
+     */
+    public function start()
+    {
+       phpdbg_start_oplog();
+    }
+
+    /**
+     * Stop collection of code coverage information.
+     *
+     * @return array
+     */
+    public function stop()
+    {
+        $sourceLines = $this->fetchSourceLines();
+
+        $dbgData = phpdbg_end_oplog(array('show_unexecuted' => true));
+        $data = $this->detectExecutedLines($sourceLines, $dbgData);
+
+        return $data;
+    }
+
+    /**
+     * Fetches all lines loaded at the time of calling, each source line marked as not executed.
+     *
+     * @return string
+     */
+    private function fetchSourceLines()
+    {
+        $sourceLines = array();
+
+        foreach(get_included_files() as $file) {
+            foreach(token_get_all(file_get_contents($file)) as $token) {
+
+                if (is_array($token)) {
+                    list($name, $data, $lineNo) = $token;
+
+                    switch($name) {
+                        case T_COMMENT:
+                        case T_DOC_COMMENT:
+                        case T_WHITESPACE:
+                            // comments and whitespaces can never be executed, therefore skip them.
+                            break;
+                        default: {
+                            $sourceLines[$file][$lineNo] = self::LINE_NOT_EXECUTED;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $sourceLines;
+    }
+
+    /**
+     * Convert phpdbg based data into the format CodeCoverage expects
+     *
+     * @param  array $sourceLines
+     * @param  array $dbgData
+     * @return array
+     */
+    private function detectExecutedLines(array $sourceLines, array $dbgData)
+    {
+        foreach ($dbgData as $file => $coveredLines) {
+            foreach($coveredLines as $lineNo => $numExecuted) {
+                $sourceLines[$file][$lineNo] = $numExecuted > 0 ? self::LINE_EXECUTED : self::LINE_NOT_EXECUTED;
+            }
+        }
+
+        return $sourceLines;
+    }
+}


### PR DESCRIPTION
Uses phpdbg to create code coverage reports, without x-debug.
Phpdbg works on opcode basis therefore code coverage numbers differ in comparison to x-debug.

The driver requires the phpdbg which is shipped with PHP7.
The features required will not be available in phpdbg+PHP5 and those are also not planned to be backported.

This driver takes all files into account which were included by the time `$codeCoverage->stop()` is called using `get_included_files`. All the coverage data is extracted from the phpdbgs' `oplog`. Files which get included after `stop` is invoked will not be part of the report (neither as covered nor uncovered).

Main selling point for this driver is that it doesn't have "external dependencies" but works with a regular php7 build (which contains tokenizer and phpdbg).

credits to @bwoebi for the phpdbg implementation part and @rdlowrey, @kelunik for discussions arround the topic.