### PR TITLE
fixes most false-positives in phpdbg code coverage. refs #361

### DIFF
--- a/src/CodeCoverage/Driver/PHPDBG.php
+++ b/src/CodeCoverage/Driver/PHPDBG.php
@@ -88,9 +88,9 @@ class PHP_CodeCoverage_Driver_PHPDBG implements PHP_CodeCoverage_Driver
             }
         }
 
-        foreach ($sourceLines as &$lines) {
-            foreach ($lines as &$line) {
-                $line = self::LINE_NOT_EXECUTED;
+        foreach ($sourceLines as $file => $lines) {
+            foreach ($lines as $lineNo => $numExecuted) {
+                $sourceLines[$file][$lineNo] = self::LINE_NOT_EXECUTED;
             }
         }
 


### PR DESCRIPTION
After manually filtering the 0-line reported coverage (which needs to be discussed in #361, how to solve),  I am getting the following result after applying this change:

```bash
mstaab@mst14:~/dvl/money$ /usr/local/php7/bin/phpdbg -rr ../phpunit/phpunit -c build
[Welcome to phpdbg, the interactive PHP debugger, v0.5.0]
To get help using phpdbg type "help" and press enter
[Please report bugs to <http://bugs.php.net/report.php>]
#!/usr/bin/env php
PHPUnit 5.0-gaa1d76f by Sebastian Bergmann and contributors.

Runtime:        PHPDBG 7.0.0-dev
Configuration:  /home/mstaab/dvl/money/build/phpunit.xml

...........ER...............................

Time: 517 ms, Memory: 12.00Mb

There was 1 error:

1) SebastianBergmann\Money\IntlFormatterTest::testMoneyObjectCanBeFormattedAsString
Error: Class 'NumberFormatter' not found

/home/mstaab/dvl/money/src/IntlFormatter.php:38
/home/mstaab/dvl/money/tests/IntlFormatterTest.php:24

--

There was 1 risky test:

1) SebastianBergmann\Money\MoneyTest::testCannotBeConstructedFromNonIntegerValue
This test executed code that is not listed as code to be covered or used:
- /home/mstaab/dvl/money/src/Money.php:473

FAILURES!
Tests: 44, Assertions: 69, Errors: 1, Risky: 1.

```

will double check now, whether the first error will disappear after compiling with `--enable-intl`

tested on php/php-src@b17ecc1e0212bb22e9bcfd9999701ab1a5e873c5