### PR TITLE
use PHP_CodeCoverage_Driver::* constants instead of magic values.

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -324,7 +324,7 @@ class PHP_CodeCoverage
             }
 
             foreach ($lines as $k => $v) {
-                if ($v == 1) {
+                if ($v == PHP_CodeCoverage_Driver::LINE_EXECUTED) {
                     if (empty($this->data[$file][$k]) || !in_array($id, $this->data[$file][$k])) {
                         $this->data[$file][$k][] = $id;
                     }
@@ -613,7 +613,7 @@ class PHP_CodeCoverage
                 $lines = count(file($uncoveredFile));
 
                 for ($i = 1; $i <= $lines; $i++) {
-                    $data[$uncoveredFile][$i] = -1;
+                    $data[$uncoveredFile][$i] = PHP_CodeCoverage_Driver::LINE_NOT_EXECUTED;
                 }
             }
         }
@@ -636,8 +636,8 @@ class PHP_CodeCoverage
             if (!isset($data[$file]) &&
                 in_array($file, $uncoveredFiles)) {
                 foreach (array_keys($fileCoverage) as $key) {
-                    if ($fileCoverage[$key] == 1) {
-                        $fileCoverage[$key] = -1;
+                    if ($fileCoverage[$key] == PHP_CodeCoverage_Driver::LINE_EXECUTED) {
+                        $fileCoverage[$key] = PHP_CodeCoverage_Driver::LINE_NOT_EXECUTED;
                     }
                 }
 


### PR DESCRIPTION
as pointed out in https://github.com/sebastianbergmann/php-code-coverage/commit/48bea1f4aa5fe4eb5547bb578bca39a5b2431915#commitcomment-12368678