### PR TITLE
Respect BlackListing/WhiteListing of merged .cov files

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -340,7 +340,7 @@ class PHP_CodeCoverage
      */
     public function merge(PHP_CodeCoverage $that)
     {
-       $this->filter->setBlacklistedFiles(
+        $this->filter->setBlacklistedFiles(
             array_merge($this->filter->getBlacklistedFiles(), $that->filter()->getBlacklistedFiles())
         );
 

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -340,6 +340,14 @@ class PHP_CodeCoverage
      */
     public function merge(PHP_CodeCoverage $that)
     {
+       $this->filter->setBlacklistedFiles(
+            array_merge($this->filter->getBlacklistedFiles(), $that->filter()->getBlacklistedFiles())
+        );
+
+        $this->filter->setWhitelistedFiles(
+            array_merge($this->filter->getWhitelistedFiles(), $that->filter()->getWhitelistedFiles())
+        );
+        
         foreach ($that->data as $file => $lines) {
             if (!isset($this->data[$file])) {
                 if (!$this->filter->isFiltered($file)) {
@@ -364,13 +372,6 @@ class PHP_CodeCoverage
 
         $this->tests = array_merge($this->tests, $that->getTests());
 
-        $this->filter->setBlacklistedFiles(
-            array_merge($this->filter->getBlacklistedFiles(), $that->filter()->getBlacklistedFiles())
-        );
-
-        $this->filter->setWhitelistedFiles(
-            array_merge($this->filter->getWhitelistedFiles(), $that->filter()->getWhitelistedFiles())
-        );
     }
 
     /**


### PR DESCRIPTION
Black Lists and White Lists of merged .cov files should be merged into their counterparts in the current coverage report *before* actually checking if a file from that report exists in a black/white list. in `$this->filter->isFiltered($file)`