### PR TITLE
Fix coverage for nested functions and classes

### DIFF
--- a/src/CodeCoverage/Report/Node/File.php
+++ b/src/CodeCoverage/Report/Node/File.php
@@ -351,7 +351,7 @@ class PHP_CodeCoverage_Report_Node_File extends PHP_CodeCoverage_Report_Node
      */
     protected function calculateStatistics()
     {
-        $classStack = $functionStack = [];
+        $classStack = $functionStack = array();
 
         if ($this->cacheTokens) {
             $tokens = PHP_Token_Stream_CachingFactory::get($this->getPath());


### PR DESCRIPTION
Some example that fails without this patch:

```php
function foo () {
	function bar () {
		return "foo";
	}

	$b = 14;
}
```

This also affects anonymous classes, they're not recognized and are named `extends` in the reports if there's a `new class extends ...`.

* for functions, `$b = 14` would be marked as executed, but doesn't count towards `foo`'s coverage.
* for anon classes, there's a lot more that breaks, so there's another issue, however, this stacked functionality will be needed, once the other issue is fixed, see #373.