### PR TITLE
fixed missing abbr closing tag

### DIFF
--- a/src/CodeCoverage/Report/HTML/Renderer/Dashboard.php
+++ b/src/CodeCoverage/Report/HTML/Renderer/Dashboard.php
@@ -213,7 +213,7 @@ class PHP_CodeCoverage_Report_HTML_Renderer_Dashboard extends PHP_CodeCoverage_R
             list($class, $method) = explode('::', $methodName);
 
             $result['method'] .= sprintf(
-                '       <tr><td><a href="%s"><abbr title="%s">%s</a></a></td><td class="text-right">%d%%</td></tr>' . "\n",
+                '       <tr><td><a href="%s"><abbr title="%s">%s</abbr></a></td><td class="text-right">%d%%</td></tr>' . "\n",
                 str_replace($baseLink, '', $classes[$class]['methods'][$method]['link']),
                 $methodName,
                 $method,


### PR DESCRIPTION
there was duplicate ```</a>``` what should have been a ```</abbr>```.
Also please backport this to 2.1 version