### PR TITLE
Removed obsolete isset()

### DIFF
--- a/src/CodeCoverage/Driver/Xdebug.php
+++ b/src/CodeCoverage/Driver/Xdebug.php
@@ -68,7 +68,7 @@ class PHP_CodeCoverage_Driver_Xdebug implements PHP_CodeCoverage_Driver
                 $numLines = $this->getNumberOfLinesInFile($file);
 
                 foreach (array_keys($data[$file]) as $line) {
-                    if (isset($data[$file][$line]) && $line > $numLines) {
+                    if ($line > $numLines) {
                         unset($data[$file][$line]);
                     }
                 }

--- a/src/CodeCoverage/Filter.php
+++ b/src/CodeCoverage/Filter.php
@@ -87,9 +87,7 @@ class PHP_CodeCoverage_Filter
     {
         $filename = realpath($filename);
 
-        if (isset($this->whitelistedFiles[$filename])) {
-            unset($this->whitelistedFiles[$filename]);
-        }
+        unset($this->whitelistedFiles[$filename]);
     }
 
     /**


### PR DESCRIPTION
Unset wont do anything in case var/array/offset doesn't exist.

Same as 1e4aa0f05ff2d234b306cdc5eb4718b7a18c0fef