### PR TITLE
Remove old feature mapTestClassNameToCoveredClassName

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -45,11 +45,6 @@ class PHP_CodeCoverage
     /**
      * @var bool
      */
-    private $mapTestClassNameToCoveredClassName = false;
-
-    /**
-     * @var bool
-     */
     private $addUncoveredFilesFromWhitelist = true;
 
     /**
@@ -423,19 +418,12 @@ class PHP_CodeCoverage
     }
 
     /**
+     * @deprecated
      * @param  bool                                      $flag
      * @throws PHP_CodeCoverage_InvalidArgumentException
      */
     public function setMapTestClassNameToCoveredClassName($flag)
     {
-        if (!is_bool($flag)) {
-            throw PHP_CodeCoverage_InvalidArgumentException::create(
-                1,
-                'boolean'
-            );
-        }
-
-        $this->mapTestClassNameToCoveredClassName = $flag;
     }
 
     /**

--- a/tests/PHP/CodeCoverageTest.php
+++ b/tests/PHP/CodeCoverageTest.php
@@ -217,28 +217,6 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
     }
 
     /**
-     * @covers PHP_CodeCoverage::setMapTestClassNameToCoveredClassName
-     */
-    public function testSetMapTestClassNameToCoveredClassName()
-    {
-        $this->coverage->setMapTestClassNameToCoveredClassName(true);
-        $this->assertAttributeEquals(
-            true,
-            'mapTestClassNameToCoveredClassName',
-            $this->coverage
-        );
-    }
-
-    /**
-     * @covers            PHP_CodeCoverage::setMapTestClassNameToCoveredClassName
-     * @expectedException PHP_CodeCoverage_Exception
-     */
-    public function testSetMapTestClassNameToCoveredClassNameThrowsExceptionForInvalidArgument()
-    {
-        $this->coverage->setMapTestClassNameToCoveredClassName(null);
-    }
-
-    /**
      * @covers PHP_CodeCoverage::clear
      */
     public function testClear()


### PR DESCRIPTION
Since v2.0 this feature does not work.

Added on https://github.com/sebastianbergmann/php-code-coverage/commit/f320e4675dc30f72f061fc88f1ddc09f24750128
Removed on https://github.com/sebastianbergmann/php-code-coverage/commit/88d167dc08bb7602a84e21294662af0fe3e8002c