### PR TITLE
#234: add optional check for unexecuted covered or used code

### DIFF
--- a/src/CodeCoverage/Exception/CoveredCodeNotExecutedException.php
+++ b/src/CodeCoverage/Exception/CoveredCodeNotExecutedException.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of the PHP_CodeCoverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Exception that is raised when covered code is not executed.
+ *
+ * @since Class available since Release 2.0.0
+ */
+class PHP_CodeCoverage_CoveredCodeNotExecutedException extends PHP_CodeCoverage_RuntimeException
+{
+}

--- a/tests/PHP/CodeCoverageTest.php
+++ b/tests/PHP/CodeCoverageTest.php
@@ -163,6 +163,28 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
     }
 
     /**
+     * @covers            PHP_CodeCoverage::setCheckForUnexecutedCoveredCode
+     * @expectedException PHP_CodeCoverage_Exception
+     */
+    public function testSetCheckForUnexecutedCoveredCodeThrowsExceptionForInvalidArgument()
+    {
+        $this->coverage->setCheckForUnexecutedCoveredCode(null);
+    }
+
+    /**
+     * @covers PHP_CodeCoverage::setCheckForUnexecutedCoveredCode
+     */
+    public function testSetCheckForUnexecutedCoveredCode()
+    {
+        $this->coverage->setCheckForUnexecutedCoveredCode(true);
+        $this->assertAttributeEquals(
+            true,
+            'checkForUnexecutedCoveredCode',
+            $this->coverage
+        );
+    }
+
+    /**
      * @covers            PHP_CodeCoverage::setAddUncoveredFilesFromWhitelist
      * @expectedException PHP_CodeCoverage_Exception
      */
@@ -473,5 +495,60 @@ class PHP_CodeCoverageTest extends PHP_CodeCoverage_TestCase
                 TEST_FILES_PATH . 'source_with_ignore.php'
             )
         );
+    }
+
+    /**
+     * @covers PHP_CodeCoverage::performUnexecutedCoveredCodeCheck
+     * @expectedException PHP_CodeCoverage_CoveredCodeNotExecutedException
+     */
+    public function testAppendThrowsExceptionIfCoveredCodeWasNotExecuted()
+    {
+        $this->coverage->filter()->addDirectoryToWhitelist(TEST_FILES_PATH);
+        $this->coverage->setCheckForUnexecutedCoveredCode(true);
+        $data = [
+            TEST_FILES_PATH . 'BankAccount.php' => [
+                29 => -1,
+                31 => -1
+            ]
+        ];
+        $linesToBeCovered = [
+            TEST_FILES_PATH . 'BankAccount.php' => [
+                22,
+                24
+            ]
+        ];
+        $linesToBeUsed = [];
+
+        $this->coverage->append($data, 'File1.php', true, $linesToBeCovered, $linesToBeUsed);
+    }
+
+    /**
+     * @covers PHP_CodeCoverage::performUnexecutedCoveredCodeCheck
+     * @expectedException PHP_CodeCoverage_CoveredCodeNotExecutedException
+     */
+    public function testAppendThrowsExceptionIfUsedCodeWasNotExecuted()
+    {
+        $this->coverage->filter()->addDirectoryToWhitelist(TEST_FILES_PATH);
+        $this->coverage->setCheckForUnexecutedCoveredCode(true);
+        $data = [
+            TEST_FILES_PATH . 'BankAccount.php' => [
+                29 => -1,
+                31 => -1
+            ]
+        ];
+        $linesToBeCovered = [
+            TEST_FILES_PATH . 'BankAccount.php' => [
+                29,
+                31
+            ]
+        ];
+        $linesToBeUsed = [
+            TEST_FILES_PATH . 'BankAccount.php' => [
+                22,
+                24
+            ]
+        ];
+
+        $this->coverage->append($data, 'File1.php', true, $linesToBeCovered, $linesToBeUsed);
     }
 }


### PR DESCRIPTION
Introduces an optional check that will throw a `PHP_CodeCoverage_CoveredCodeNotExecutedException` if code that is referenced in `@covers` or `@uses` is not executed. 

The check can be activated by calling `PHP_CodeCoverage::setCheckForUnexecutedCoveredCode(true)`.

Please have a look at the unit tests, as I am not exactly sure if they comply with the current test base,
`PHP_CodeCoverageTest::testAppendThrowsExceptionIfCoveredCodeWasNotExecuted()` and `PHP_CodeCoverageTest::testAppendThrowsExceptionIfUsedCodeWasNotExecuted()` in particular.