### PR TITLE
Fixes issue #416 in https://github.com/sebastianbergmann/php-code-cov…

### DIFF
--- a/src/CodeCoverage/Driver/Xdebug.php
+++ b/src/CodeCoverage/Driver/Xdebug.php
@@ -38,7 +38,7 @@ class PHP_CodeCoverage_Driver_Xdebug implements PHP_CodeCoverage_Driver
      */
     public function start()
     {
-        xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+        xdebug_start_code_coverage(XDEBUG_CC_UNUSED);
     }
 
     /**


### PR DESCRIPTION
…erage. PHP7 will SIGSEGV if the dead code option is passed in xdebug start code coverage method.