### PR TITLE
Ignore "xdebug://debug-eval(1) : eval()'d code"

### DIFF
--- a/src/CodeCoverage/Driver/Xdebug.php
+++ b/src/CodeCoverage/Driver/Xdebug.php
@@ -64,7 +64,7 @@ class PHP_CodeCoverage_Driver_Xdebug implements PHP_CodeCoverage_Driver
         foreach (array_keys($data) as $file) {
             unset($data[$file][0]);
 
-            if ($file != 'xdebug://debug-eval' && file_exists($file)) {
+            if (strpos($file,'xdebug://debug-eval') !== 0 && file_exists($file)) {
                 $numLines = $this->getNumberOfLinesInFile($file);
 
                 foreach (array_keys($data[$file]) as $line) {


### PR DESCRIPTION
The previous implementation does not work in my case because the xdebug file is "xdebug://debug-eval(1) : eval()'d code". With this check now, it is the behaviour from before and allow to exclude my xdebug "file"