### PR TITLE
Fixed bug that causes erroneous uncovered lines under PHPDBG.

### DIFF
--- a/src/CodeCoverage/Driver/PHPDBG.php
+++ b/src/CodeCoverage/Driver/PHPDBG.php
@@ -55,6 +55,7 @@ class PHP_CodeCoverage_Driver_PHPDBG implements PHP_CodeCoverage_Driver
 
         if ($fetchedLines == []) {
             $sourceLines = phpdbg_get_executable();
+            $newFiles = array_keys($sourceLines);
         } else {
             $newFiles = array_diff(
                 get_included_files(),
@@ -70,13 +71,15 @@ class PHP_CodeCoverage_Driver_PHPDBG implements PHP_CodeCoverage_Driver
             }
         }
 
-        foreach ($sourceLines as $file => $lines) {
-            foreach ($lines as $lineNo => $numExecuted) {
-                $sourceLines[$file][$lineNo] = self::LINE_NOT_EXECUTED;
-            }
+        foreach ($newFiles as $file) {
+            $fetchedLines[$file] = $sourceLines[$file];
         }
 
-        $fetchedLines = array_merge($fetchedLines, $sourceLines);
+        foreach ($fetchedLines as $file => $lines) {
+            foreach ($lines as $lineNo => $status) {
+                $fetchedLines[$file][$lineNo] = self::LINE_NOT_EXECUTED;
+            }
+        }
 
         return $this->detectExecutedLines($fetchedLines, $dbgData);
     }


### PR DESCRIPTION
I was attempting to run code coverage under PHP 7 PHPDBG and came across an issue where lines that should appear as covered were appearing as uncovered.

After some investigation, the issue seems to be caused by some strange behaviour in `phpdbg_get_executable()`. I lodged krakjoe/phpdbg#152 to address what I believe to be the cause of this bug, but this PR is a workaround for the current state of affairs.

The issue is that `phpdbg_get_executable()`, when called with the "files" option, can sometimes return information about files other than the ones specified in the "files" option. In addition, when this happens, the "additional" files can sometimes have only a subset of the *actual* executable lines in each file. Because of the way `$fetchedLines` and `$sourceLines` were being merged, executable lines could "disappear" in subsequent calls to `stop()`.

This PR avoids the issue by only adding new data to `$fetchedLines` for the specific files that were requested in the "files" option when calling `phpdbg_get_executable()`.
