### PR TITLE
In order to support PHP 7.0, token stream PHP7 tokens are required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "irc": "irc://irc.freenode.net/phpunit"
     },
     "require": {
-        "php": ">=5.6",
+        "php": "^5.6 || ^7.0",
         "phpunit/php-file-iterator": "~1.3",
-        "phpunit/php-token-stream": "~1.3",
+        "phpunit/php-token-stream": "^1.4.2",
         "phpunit/php-text-template": "~1.2",
         "sebastian/code-unit-reverse-lookup": "~1.0",
         "sebastian/environment": "^1.3.2",


### PR DESCRIPTION
New tokens were included in `phpunit/php-token-stream:1.4.2` (see https://github.com/sebastianbergmann/php-token-stream/commit/db63be1159c81df649cd0260e30249a586d4129e#diff-07ca42cd43d34e41ef921ccbe0e830deR713)

Without these tokens, this package is not compatible with PHP 7.0, and running coverage will result in a fatal error