### PR TITLE
Add missing status type 6 (warning)

### DIFF
--- a/src/Report/Xml/Tests.php
+++ b/src/Report/Xml/Tests.php
@@ -20,7 +20,8 @@ class Tests
         2 => 'INCOMPLETE', // PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE
         3 => 'FAILURE',    // PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE
         4 => 'ERROR',      // PHPUnit_Runner_BaseTestRunner::STATUS_ERROR
-        5 => 'RISKY'       // PHPUnit_Runner_BaseTestRunner::STATUS_RISKY
+        5 => 'RISKY',      // PHPUnit_Runner_BaseTestRunner::STATUS_RISKY
+        6 => 'WARNING'     // PHPUnit_Runner_BaseTestRunner::STATUS_WARNING
     ];
 
     public function __construct(\DOMElement $context)


### PR DESCRIPTION
Implementing [phpunit/#1802](https://github.com/sebastianbergmann/phpunit/issues/1802) added a new status type which somehow never made it into the XML Coverage Report.
That lead to the following error condition:

```bash
     [exec] PHP Notice:  Undefined offset: 6 in phar:///usr/bin/phpunit/php-code-coverage/Report/Xml/Tests.php on line 43
     [exec] PHP Stack trace:
     [exec] PHP   1. {main}() /usr/bin/phpunit:0
     [exec] PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:569
     [exec] PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:113
     [exec] PHP   4. PHPUnit_TextUI_TestRunner->doRun() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:162
     [exec] PHP   5. SebastianBergmann\CodeCoverage\Report\Xml\Facade->process() phar:///usr/bin/phpunit/phpunit/TextUI/TestRunner.php:583
     [exec] PHP   6. SebastianBergmann\CodeCoverage\Report\Xml\Facade->processTests() phar:///usr/bin/phpunit/php-code-coverage/Report/Xml/Facade.php:52
     [exec] PHP   7. SebastianBergmann\CodeCoverage\Report\Xml\Tests->addTest() phar:///usr/bin/phpunit/php-code-coverage/Report/Xml/Facade.php:210
```

This PR should fix that by adding the missing status type