### PR TITLE
Tooltip fuction requires key instead of graph parameter

### DIFF
--- a/src/Report/Html/Renderer/Template/dashboard.html.dist
+++ b/src/Report/Html/Renderer/Template/dashboard.html.dist
@@ -216,7 +216,7 @@ $(document).ready(function() {
       .showLegend(false)
       .forceX([0, 100]);
     chart.tooltipContent(function(key, y, e, graph) {
-      return '<p>' + graph.point.class + '</p>';
+      return '<p>' + key.point.class + '</p>';
     });
 
     chart.xAxis.axisLabel('Code Coverage (in percent)');
@@ -240,7 +240,7 @@ $(document).ready(function() {
       .showLegend(false)
       .forceX([0, 100]);
     chart.tooltipContent(function(key, y, e, graph) {
-      return '<p>' + graph.point.class + '</p>';
+      return '<p>' + key.point.class + '</p>';
     });
 
     chart.xAxis.axisLabel('Code Coverage (in percent)');


### PR DESCRIPTION
What I'm using
Generated by php-code-coverage 4.0.1 using PHP 7.0.6 with Xdebug 2.4.1 and PHPUnit 5.5.0 at Sun Aug 7 0:39:01 UTC 2016.

OS: Windows
Browser: Chrome

I get an error  Uncaught TypeError: Cannot read property 'point' of undefined
