### PR TITLE
Fix for #476

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -361,6 +361,8 @@ class CodeCoverage
         $this->tests[$id] = ['size' => $size, 'status' => $status];
 
         foreach ($data as $file => $lines) {
+            $file = $this->filter->unifyFilename($file);
+
             if (!$this->filter->isFile($file)) {
                 continue;
             }
@@ -387,6 +389,8 @@ class CodeCoverage
         );
 
         foreach ($that->data as $file => $lines) {
+            $file = $this->filter->unifyFilename($file);
+
             if (!isset($this->data[$file])) {
                 if (!$this->filter->isFiltered($file)) {
                     $this->data[$file] = $lines;
@@ -680,6 +684,8 @@ class CodeCoverage
     private function initializeFilesThatAreSeenTheFirstTime(array $data)
     {
         foreach ($data as $file => $lines) {
+            $file = $this->filter->unifyFilename($file);
+
             if ($this->filter->isFile($file) && !isset($this->data[$file])) {
                 $this->data[$file] = [];
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -46,7 +46,7 @@ class Filter
      */
     public function addFileToWhitelist($filename)
     {
-        $this->whitelistedFiles[realpath($filename)] = true;
+        $this->whitelistedFiles[$this->unifyFilename($filename)] = true;
     }
 
     /**
@@ -85,7 +85,7 @@ class Filter
      */
     public function removeFileFromWhitelist($filename)
     {
-        $filename = realpath($filename);
+        $filename = $this->unifyFilename($filename);
 
         unset($this->whitelistedFiles[$filename]);
     }
@@ -126,7 +126,7 @@ class Filter
             return true;
         }
 
-        $filename = realpath($filename);
+        $filename = $this->unifyFilename($filename);
 
         return !isset($this->whitelistedFiles[$filename]);
     }
@@ -166,8 +166,24 @@ class Filter
      *
      * @param array $whitelistedFiles
      */
-    public function setWhitelistedFiles($whitelistedFiles)
+    public function setWhitelistedFiles(array $whitelistedFiles)
     {
         $this->whitelistedFiles = $whitelistedFiles;
+
+        $this->addFilesToWhitelist(array_keys($whitelistedFiles));
+    }
+
+    /**
+     * Gets unified filename with lower-cased directory path and original name of file.
+     *
+     * @param string $filename
+     *
+     * @return string
+     */
+    public function unifyFilename($filename)
+    {
+        $filename = realpath($filename);
+
+        return strtolower(dirname($filename)) . DIRECTORY_SEPARATOR . basename($filename);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -232,8 +232,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getExpectedDataArrayForBankAccount()
     {
+        $filter = new Filter();
+
         return [
-            TEST_FILES_PATH . 'BankAccount.php' => [
+            $filter->unifyFilename(TEST_FILES_PATH . 'BankAccount.php') => [
                 8 => [
                     0 => 'BankAccountTest::testBalanceIsInitiallyZero',
                     1 => 'BankAccountTest::testDepositWithdrawMoney'

--- a/tests/tests/BuilderTest.php
+++ b/tests/tests/BuilderTest.php
@@ -10,6 +10,7 @@
 
 namespace SebastianBergmann\CodeCoverage\Report;
 
+use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\TestCase;
 use SebastianBergmann\CodeCoverage\Node\Builder;
 
@@ -25,8 +26,9 @@ class BuilderTest extends TestCase
     public function testSomething()
     {
         $root = $this->getCoverageForBankAccount()->getReport();
+        $filter = new Filter();
 
-        $expectedPath = rtrim(TEST_FILES_PATH, DIRECTORY_SEPARATOR);
+        $expectedPath = $filter->unifyFilename(rtrim(TEST_FILES_PATH, DIRECTORY_SEPARATOR));
         $this->assertEquals($expectedPath, $root->getName());
         $this->assertEquals($expectedPath, $root->getPath());
         $this->assertEquals(10, $root->getNumExecutableLines());

--- a/tests/tests/FilterTest.php
+++ b/tests/tests/FilterTest.php
@@ -69,6 +69,12 @@ class FilterTest extends \PHPUnit_Framework_TestCase
             TEST_FILES_PATH . 'source_without_ignore.php',
             TEST_FILES_PATH . 'source_without_namespace.php'
         ];
+
+        $filter = $this->filter;
+
+        $this->files = array_map(function($file) use ($filter) {
+            return $filter->unifyFilename($file);
+        }, $this->files);
     }
 
     /**
@@ -78,9 +84,10 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testAddingAFileToTheWhitelistWorks()
     {
         $this->filter->addFileToWhitelist($this->files[0]);
+        $expected = $this->filter->unifyFilename($this->files[0]);
 
         $this->assertEquals(
-            [$this->files[0]],
+            [$expected],
             $this->filter->getWhitelist()
         );
     }


### PR DESCRIPTION
Fix for https://github.com/sebastianbergmann/php-code-coverage/issues/476

After the fix I get the same results of coverage on both OS.

Updates:
- change the way of storing whitelisted files;
- update tests to make them pass.

![image](https://cloud.githubusercontent.com/assets/3897579/19819595/54d31626-9d4d-11e6-9861-588b2ce0b8df.png)
