### PR TITLE
Fix RuntimeException with nonexisting directory

### DIFF
--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -10,6 +10,7 @@
 
 namespace SebastianBergmann\CodeCoverage\Report\Html;
 
+use RuntimeException;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Node\Directory as DirectoryNode;
 


### PR DESCRIPTION
(Sorry, I had no time to write a test. Feel free to close this PR and implement the fix in an own commit.)

## How to reproduce

Run phpunit with a not existing directory in the `--coverage-html` parameter:

```shell
vendor/bin/phpunit --coverage-html /not/existing/directory
PHPUnit 5.6.2 by Sebastian Bergmann and contributors.

.............................................                     45 / 45 (100%)

Time: 676 ms, Memory: 10.00MB

OK (45 tests, 124 assertions)

Generating code coverage report in HTML format ...PHP Fatal error:  Uncaught Error: Class 'SebastianBergmann\CodeCoverage\Report\Html\RuntimeException' not found in [...]/vendor/phpunit/php-code-coverage/src/Report/Html/Facade.php:171
Stack trace:
#0 [...]/vendor/phpunit/php-code-coverage/src/Report/Html/Facade.php(62): SebastianBergmann\CodeCoverage\Report\Html\Facade->getDirectory('/cache/coverage...')
#1 [...]/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(526): SebastianBergmann\CodeCoverage\Report\Html\Facade->process(Object(SebastianBergmann\CodeCoverage\CodeCoverage), '/cache/coverage')
#2 [...]/vendor/phpunit/phpunit/src/TextUI/Command.php(185): PHPUnit_TextUI_TestRunner->doRun(Array, true)
#3 [...]/vendor/phpunit/phpunit/src/TextUI/Command.php(115): PHPUnit_TextUI_Command->run(Array, true)
#4 [...]/vendor/phpunit/phpunit/phpunit(47): PHPUnit_TextUI_Command::m in [...]/vendor/phpunit/php-code-coverage/src/Report/Html/Facade.php on line 171
```