### PR TITLE
force serialize_precision to ensure test pass with 5.6, 7.0 and 7.1

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,5 +13,9 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <ini name="serialize_precision" value="14"/>
+    </php>
 </phpunit>
 

--- a/tests/_files/Report/HTML/CoverageForClassWithAnonymousFunction/dashboard.html
+++ b/tests/_files/Report/HTML/CoverageForClassWithAnonymousFunction/dashboard.html
@@ -251,7 +251,7 @@ $(document).ready(function() {
     chart.yAxis.axisLabel('Method Complexity');
 
     d3.select('#methodComplexity svg')
-      .datum(getComplexityData([[66.666666666666657,1,"<a href=\"source_with_class_and_anonymous_function.php.html#5\">CoveredClassWithAnonymousFunctionInStaticMethod::runAnonymous<\/a>"],[100,1,"<a href=\"source_with_class_and_anonymous_function.php.html#11\">CoveredClassWithAnonymousFunctionInStaticMethod::anonymous function<\/a>"]], 'Method Complexity'))
+      .datum(getComplexityData([[66.666666666667,1,"<a href=\"source_with_class_and_anonymous_function.php.html#5\">CoveredClassWithAnonymousFunctionInStaticMethod::runAnonymous<\/a>"],[100,1,"<a href=\"source_with_class_and_anonymous_function.php.html#11\">CoveredClassWithAnonymousFunctionInStaticMethod::anonymous function<\/a>"]], 'Method Complexity'))
       .transition()
       .duration(500)
       .call(chart);


### PR DESCRIPTION
Up to PHP 7.0, "precision" is used (default value is 14)
Since PHP 7.1, "serialize_precision" is used.