### PR TITLE
Ignore Hack enum declarations

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -866,6 +866,10 @@ class CodeCoverage
                         }
                         break;
 
+                    case 'PHP_Token_ENUM':
+                        $this->ignoredLines[$filename][] = $token->getLine();
+                        break;
+
                     case 'PHP_Token_NAMESPACE':
                         $this->ignoredLines[$filename][] = $token->getEndLine();
 


### PR DESCRIPTION
Without this, phpunit incorrectly considers this to be untested executable code:
https://github.com/hhvm/hack-codegen/blob/master/src/CodegenWithVisibility.php#L13

Tested with:

```
hhvm -d hhvm.jit=0 -d hhvm.enable_call_builtin=0 -d xdebug.enable=1 vendor/bin/phpunit --coverage-html ./coverage
```

against https://github.com/hhvm/hack-codegen