### PR TITLE
Add option to ignore covers annotation

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -59,6 +59,11 @@ final class CodeCoverage
     /**
      * @var bool
      */
+    private $ignoreCoversAnnotation = false;
+
+    /**
+     * @var bool
+     */
     private $checkForUnexecutedCoveredCode = false;
 
     /**
@@ -417,6 +422,11 @@ final class CodeCoverage
         $this->forceCoversAnnotation = $flag;
     }
 
+    public function setIgnoreCoversAnnotation(bool $flag): void
+    {
+        $this->ignoreCoversAnnotation = $flag;
+    }
+
     public function setCheckForMissingCoversAnnotation(bool $flag): void
     {
         $this->checkForMissingCoversAnnotation = $flag;
@@ -464,6 +474,10 @@ final class CodeCoverage
      */
     private function applyCoversAnnotationFilter(array &$data, $linesToBeCovered, array $linesToBeUsed, bool $ignoreForceCoversAnnotation): void
     {
+        if ($this->ignoreCoversAnnotation) {
+            return;
+        }
+
         if ($linesToBeCovered === false ||
             ($this->forceCoversAnnotation && empty($linesToBeCovered) && !$ignoreForceCoversAnnotation)) {
             if ($this->checkForMissingCoversAnnotation) {

--- a/tests/tests/CodeCoverageTest.php
+++ b/tests/tests/CodeCoverageTest.php
@@ -157,6 +157,17 @@ class CodeCoverageTest extends TestCase
         );
     }
 
+    public function testIgnoreCoversAnnotation()
+    {
+        $this->coverage->setIgnoreCoversAnnotation(true);
+
+        $this->assertAttributeEquals(
+            true,
+            'ignoreCoversAnnotation',
+            $this->coverage
+        );
+    }
+
     public function testSetCheckForUnexecutedCoveredCode()
     {
         $this->coverage->setCheckForUnexecutedCoveredCode(true);


### PR DESCRIPTION
This PR:

* Adds the option to ignore coverage annotations, as mentioned in #571 
 
If preferred, i can also make a PR against v5.3 instead