### PR TITLE
Safer mkdir()

### DIFF
--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -94,7 +94,7 @@ final class Facade
             $id = $node->getId();
 
             if ($node instanceof DirectoryNode) {
-                if (!@\mkdir($target . $id, 0777, true) && !\is_dir($target . $id)) {
+                if (!self::mkdir($target . $id, 0777, true) && !\is_dir($target . $id)) {
                     throw new \RuntimeException(\sprintf('Directory "%s" was not created', $target . $id));
                 }
 
@@ -103,7 +103,7 @@ final class Facade
             } else {
                 $dir = \dirname($target . $id);
 
-                if (!@\mkdir($dir, 0777, true) && !\is_dir($dir)) {
+                if (!self::mkdir($dir, 0777, true) && !\is_dir($dir)) {
                     throw new \RuntimeException(\sprintf('Directory "%s" was not created', $dir));
                 }
 
@@ -161,7 +161,7 @@ final class Facade
             $directory .= DIRECTORY_SEPARATOR;
         }
 
-        if (!@\mkdir($directory, 0777, true) && !\is_dir($directory)) {
+        if (!self::mkdir($directory, 0777, true) && !\is_dir($directory)) {
             throw new RuntimeException(
                 \sprintf(
                     'Directory "%s" does not exist.',
@@ -171,5 +171,17 @@ final class Facade
         }
 
         return $directory;
+    }
+
+    private function mkdir(string $directory, int $mode, bool $recursive): bool
+    {
+        \set_error_handler(function () {
+        });
+
+        $result = \mkdir($directory, $mode, $recursive);
+
+        \restore_error_handler();
+
+        return $result;
     }
 }

--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -90,7 +90,7 @@ final class Facade
                     "'$directory' exists but is not writable."
                 );
             }
-        } elseif (!@\mkdir($directory, 0777, true)) {
+        } elseif (!self::mkdir($directory, 0777, true)) {
             throw new RuntimeException(
                 "'$directory' could not be created."
             );
@@ -279,5 +279,17 @@ final class Facade
         $this->initTargetDirectory(\dirname($filename));
 
         $document->save($filename);
+    }
+
+    private function mkdir(string $directory, int $mode, bool $recursive): bool
+    {
+        \set_error_handler(function () {
+        });
+
+        $result = \mkdir($directory, $mode, $recursive);
+
+        \restore_error_handler();
+
+        return $result;
     }
 }


### PR DESCRIPTION
Hi,

I recently updated to PHPUnit 7.1 and I'm now getting an exception while generating code coverage:

```
Generating code coverage report in HTML format ...
[Uncaught ErrorException in /server/http/vendor/phpunit/php-code-coverage/src/Report/Html/Facade.php on line 106]
ErrorException: mkdir(): File exists in /server/http/vendor/phpunit/php-code-coverage/src/Report/Html/Facade.php:106
Stack trace:
#0 [internal function]: PHPUnit\Util\FileLoader::HelloFresh\RecipeService\{closure}(2, 'mkdir(): File e...', '/server/http/ve...', 106, Array)
#1 /server/http/vendor/phpunit/php-code-coverage/src/Report/Html/Facade.php(106): mkdir('build/coverage', 511, true)
#2 /server/http/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(568): SebastianBergmann\CodeCoverage\Report\Html\Facade->process(Object(SebastianBergmann\CodeCoverage\CodeCoverage), 'build/coverage/')
#3 /server/http/vendor/phpunit/phpunit/src/TextUI/Command.php(205): PHPUnit\TextUI\TestRunner->doRun(Object(PHPUnit\Framework\TestSuite), Array, true)
#4 /server/http/vendor/phpunit/phpunit/src/TextUI/Command.php(153): PHPUnit\TextUI\Command->run(Array, true)
#5 /server/http/vendor/phpunit/phpunit/phpunit(53): PHPUnit\TextUI\Command::main()
#6 {main}
make: *** [Makefile:49: test-coverage] Error 255
```

That's because we are turning errors into exception and silencers (`@`) are used in the `Facade`.

This PR removes the silencers and decorates `mkdir` with custom error handlers.