### PR TITLE
Fix creation of the directory for reports

### DIFF
--- a/src/Report/Clover.php
+++ b/src/Report/Clover.php
@@ -234,7 +234,7 @@ final class Clover
         $buffer = $xmlDocument->saveXML();
 
         if ($target !== null) {
-            if (!@\mkdir(\dirname($target), 0777, true) && !\is_dir(\dirname($target))) {
+            if (!\is_dir(\dirname($target)) && !\mkdir(\dirname($target), 0777, true)) {
                 throw new \RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
             }
 


### PR DESCRIPTION
The attempt to create already existing directory leads to `ErrorException` and not to PHP errors in new PHP, so the suppress errors with `@` is not working.