### PR TITLE
Fix: Import exception and add docblock

### DIFF
--- a/src/Report/PHP.php
+++ b/src/Report/PHP.php
@@ -11,12 +11,21 @@
 namespace SebastianBergmann\CodeCoverage\Report;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\RuntimeException;
 
 /**
  * Uses var_export() to write a SebastianBergmann\CodeCoverage\CodeCoverage object to a file.
  */
 final class PHP
 {
+    /**
+     * @param CodeCoverage $coverage
+     * @param null|string  $target
+     *
+     * @throws \SebastianBergmann\CodeCoverage\RuntimeException
+     *
+     * @return string
+     */
     public function process(CodeCoverage $coverage, ?string $target = null): string
     {
         $filter = $coverage->filter();


### PR DESCRIPTION
This PR

* [x] imports an otherwise undefined exception and adds a docblock

Follows https://github.com/sebastianbergmann/php-code-coverage/commit/6d6e40862776020467b22f20f032197c02963097.