### PR TITLE
Fix PHP Error on mkdir() on existing directory

### DIFF
--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -94,7 +94,7 @@ final class Facade
             $id = $node->getId();
 
             if ($node instanceof DirectoryNode) {
-                if (!@\mkdir($target . $id, 0777, true) && !\is_dir($target . $id)) {
+                if (!$this->createDirectory($target . $id)) {
                     throw new \RuntimeException(\sprintf('Directory "%s" was not created', $target . $id));
                 }
 
@@ -103,7 +103,7 @@ final class Facade
             } else {
                 $dir = \dirname($target . $id);
 
-                if (!@\mkdir($dir, 0777, true) && !\is_dir($dir)) {
+                if (!$this->createDirectory($dir)) {
                     throw new \RuntimeException(\sprintf('Directory "%s" was not created', $dir));
                 }
 
@@ -160,8 +160,8 @@ final class Facade
         if (\substr($directory, -1, 1) != DIRECTORY_SEPARATOR) {
             $directory .= DIRECTORY_SEPARATOR;
         }
-
-        if (!@\mkdir($directory, 0777, true) && !\is_dir($directory)) {
+        
+        if (!$this->createDirectory($directory)) {
             throw new RuntimeException(
                 \sprintf(
                     'Directory "%s" does not exist.',
@@ -171,5 +171,16 @@ final class Facade
         }
 
         return $directory;
+    }
+    
+    private function createDirectory(string $directory): bool
+    {
+        if (!\is_dir($directory)) {
+            if (!@\mkdir($directory)) {
+                return false;
+            }
+        }
+        
+        return true;
     }
 }

--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -176,7 +176,7 @@ final class Facade
     private function createDirectory(string $directory): bool
     {
         if (!\is_dir($directory)) {
-            if (!@\mkdir($directory)) {
+            if (!@\mkdir($directory, 0777, true)) {
                 return false;
             }
         }


### PR DESCRIPTION
I cannot do code-coverage because we have a custom error handler that converts PHP Errors into exceptions.

The problem here was that mkdir() was executed before is_dir(). I reversed the direction of these calls (is_dir() before mkdir()) and made them into a function, since the same logic was three times in the class.