### PR TITLE
Fix file_exists() on non-file

### DIFF
--- a/src/Driver/Xdebug.php
+++ b/src/Driver/Xdebug.php
@@ -66,7 +66,7 @@ final class Xdebug implements Driver
         foreach (\array_keys($data) as $file) {
             unset($data[$file][0]);
 
-            if (\strpos($file, 'xdebug://debug-eval') !== 0 && \file_exists($file)) {
+            if (\strpos($file, 'xdebug://debug-eval') !== 0 && $file !== 'Standard input code' && \file_exists($file)) {
                 $numLines = $this->getNumberOfLinesInFile($file);
 
                 foreach (\array_keys($data[$file]) as $line) {


### PR DESCRIPTION
file_exists() causes an error when open_basedir is set, because it uses the non-file `Standard input code`.