### PR TITLE
Fix a crash that can occur when php-token-stream parses invalid files

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage;
 
+use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\Util\Test;
@@ -611,7 +612,17 @@ final class CodeCoverage
         if (isset($this->ignoredLines[$fileName])) {
             return $this->ignoredLines[$fileName];
         }
+        try {
+            return $this->getLinesToBeIgnoredInner($fileName);
+        } catch (OutOfBoundsException $e) {
+            // This can happen with PHP_Token_Stream if the file is syntactically invalid,
+            // and probably affects a file that wasn't executed.
+            return [];
+        }
+    }
 
+    private function getLinesToBeIgnoredInner(string $fileName): array
+    {
         $this->ignoredLines[$fileName] = [];
 
         $lines = \file($fileName);

--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianBergmann\CodeCoverage\Node;
 
+use OutOfBoundsException;
+
 /**
  * Represents a file in the code coverage information tree.
  */
@@ -341,9 +343,14 @@ final class File extends AbstractNode
             $this->codeUnitsByLine[$lineNumber] = [];
         }
 
-        $this->processClasses($tokens);
-        $this->processTraits($tokens);
-        $this->processFunctions($tokens);
+        try {
+            $this->processClasses($tokens);
+            $this->processTraits($tokens);
+            $this->processFunctions($tokens);
+        } catch (OutOfBoundsException $e) {
+            // This can happen with PHP_Token_Stream if the file is syntactically invalid,
+            // and probably affects a file that wasn't executed.
+        }
         unset($tokens);
 
         foreach (\range(1, $this->linesOfCode['loc']) as $lineNumber) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -374,4 +374,27 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         return $stub;
     }
+
+    protected function getCoverageForCrashParsing()
+    {
+        $filter = new Filter;
+        $filter->addFileToWhitelist(TEST_FILES_PATH . 'Crash.php');
+
+        // This is a file with invalid syntax, so it isn't executed.
+        return new CodeCoverage(
+            $this->setUpXdebugStubForCrashParsing(),
+            $filter
+        );
+    }
+
+    protected function setUpXdebugStubForCrashParsing()
+    {
+        $stub = $this->createMock(Driver::class);
+
+        $stub->expects($this->any())
+            ->method('stop')
+            ->will($this->returnValue([]));
+        return $stub;
+    }
+
 }

--- a/tests/_files/Crash.php
+++ b/tests/_files/Crash.php
@@ -1,0 +1,2 @@
+<?php
+class {CLASS}

--- a/tests/tests/BuilderTest.php
+++ b/tests/tests/BuilderTest.php
@@ -10,6 +10,9 @@
 
 namespace SebastianBergmann\CodeCoverage\Report;
 
+use SebastianBergmann\CodeCoverage\Driver\Driver;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\TestCase;
 use SebastianBergmann\CodeCoverage\Node\Builder;
 
@@ -123,6 +126,21 @@ class BuilderTest extends TestCase
         );
 
         $this->assertEquals([], $root->getFunctions());
+    }
+
+    public function testNotCrashParsing()
+    {
+        $coverage = $this->getCoverageForCrashParsing();
+        $root = $coverage->getReport();
+
+        $expectedPath = rtrim(TEST_FILES_PATH, DIRECTORY_SEPARATOR);
+        $this->assertEquals($expectedPath, $root->getName());
+        $this->assertEquals($expectedPath, $root->getPath());
+        $this->assertEquals(2, $root->getNumExecutableLines());
+        $this->assertEquals(0, $root->getNumExecutedLines());
+        $data = $coverage->getData();
+        $expectedFile = $expectedPath . DIRECTORY_SEPARATOR . 'Crash.php';
+        $this->assertSame([$expectedFile => [1 => [], 2 => []]], $data);
     }
 
     public function testBuildDirectoryStructure()

--- a/tests/tests/FilterTest.php
+++ b/tests/tests/FilterTest.php
@@ -52,6 +52,7 @@ class FilterTest extends TestCase
             TEST_FILES_PATH . 'CoverageTwoDefaultClassAnnotations.php',
             TEST_FILES_PATH . 'CoveredClass.php',
             TEST_FILES_PATH . 'CoveredFunction.php',
+            TEST_FILES_PATH . 'Crash.php',
             TEST_FILES_PATH . 'NamespaceCoverageClassExtendedTest.php',
             TEST_FILES_PATH . 'NamespaceCoverageClassTest.php',
             TEST_FILES_PATH . 'NamespaceCoverageCoversClassPublicTest.php',


### PR DESCRIPTION
This can happen when an invalid file is in the whitelist or a
whitelisted folder.