### PR TITLE
Make the code more testable

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -919,13 +919,13 @@ final class CodeCoverage
         \sort($unintentionallyCoveredUnits);
 
         foreach ((array)$unintentionallyCoveredUnits as $index => $FQNMethod) {
-            $className = \explode('::', $FQNMethod);
+            $unit = \explode('::', $FQNMethod);
 
-            if (\count($className) !== 2) {
+            if (\count($unit) !== 2) {
                 continue;
             }
 
-            $class = new \ReflectionClass($className[0]);
+            $class = new \ReflectionClass($unit[0]);
 
             foreach ($this->unintentionallyCoveredSubclassesWhitelist as $whitelisted) {
                 if ($class->isSubclassOf($whitelisted)) {

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -32,7 +32,7 @@ final class CodeCoverage
     private $driver;
 
     /**
-     * @var Filter
+     * @var Sieve
      */
     private $filter;
 
@@ -40,11 +40,6 @@ final class CodeCoverage
      * @var Wizard
      */
     private $wizard;
-
-    /**
-     * @var bool
-     */
-    private $cacheTokens = false;
 
     /**
      * @var bool
@@ -77,11 +72,6 @@ final class CodeCoverage
     private $processUncoveredFilesFromWhitelist = false;
 
     /**
-     * @var bool
-     */
-    private $ignoreDeprecatedCode = false;
-
-    /**
      * @var PhptTestCase|string|TestCase
      */
     private $currentId;
@@ -92,16 +82,6 @@ final class CodeCoverage
      * @var array
      */
     private $data = [];
-
-    /**
-     * @var array
-     */
-    private $ignoredLines = [];
-
-    /**
-     * @var bool
-     */
-    private $disableIgnoredLines = false;
 
     /**
      * Test data.
@@ -135,9 +115,24 @@ final class CodeCoverage
     private $report;
 
     /**
+     * @var \Closure
+     */
+    private $evaluateWhitelistedFile;
+
+    /**
+     * @var LineSieve
+     */
+    private $lineFilter;
+
+    /**
      * @throws RuntimeException
      */
-    public function __construct(Driver $driver = null, Filter $filter = null)
+    public function __construct(
+        Driver $driver = null,
+        Sieve $filter = null,
+        \Closure $evaluateWhitelistedFile = null,
+        LineSieve $lineFilter = null
+    )
     {
         if ($filter === null) {
             $filter = new Filter;
@@ -147,8 +142,20 @@ final class CodeCoverage
             $driver = $this->selectDriver($filter);
         }
 
-        $this->driver = $driver;
-        $this->filter = $filter;
+        if ($evaluateWhitelistedFile === null) {
+            $evaluateWhitelistedFile = function(string $file){
+                include_once $file;
+            };
+        }
+
+        if ($lineFilter === null) {
+            $lineFilter = new LineFilter();
+        }
+
+        $this->driver                  = $driver;
+        $this->filter                  = $filter;
+        $this->evaluateWhitelistedFile = $evaluateWhitelistedFile;
+        $this->lineFilter              = $lineFilter;
 
         $this->wizard = new Wizard;
     }
@@ -182,7 +189,7 @@ final class CodeCoverage
     /**
      * Returns the filter object used.
      */
-    public function filter(): Filter
+    public function filter(): Sieve
     {
         return $this->filter;
     }
@@ -406,12 +413,12 @@ final class CodeCoverage
 
     public function setCacheTokens(bool $flag): void
     {
-        $this->cacheTokens = $flag;
+        $this->lineFilter->setCacheTokens($flag);
     }
 
     public function getCacheTokens(): bool
     {
-        return $this->cacheTokens;
+        return $this->lineFilter->getCacheTokens();
     }
 
     public function setCheckForUnintentionallyCoveredCode(bool $flag): void
@@ -446,12 +453,12 @@ final class CodeCoverage
 
     public function setDisableIgnoredLines(bool $flag): void
     {
-        $this->disableIgnoredLines = $flag;
+        $this->lineFilter->setDisableIgnoredLines($flag);
     }
 
     public function setIgnoreDeprecatedCode(bool $flag): void
     {
-        $this->ignoreDeprecatedCode = $flag;
+        $this->lineFilter->setIgnoreDeprecatedCode($flag);
     }
 
     public function setUnintentionallyCoveredSubclassesWhitelist(array $whitelist): void
@@ -555,7 +562,7 @@ final class CodeCoverage
                 continue;
             }
 
-            foreach ($this->getLinesToBeIgnored($filename) as $line) {
+            foreach ($this->lineFilter->getLinesToBeIgnored($filename) as $line) {
                 unset($data[$filename][$line]);
             }
         }
@@ -606,190 +613,6 @@ final class CodeCoverage
         }
 
         $this->append($data, 'UNCOVERED_FILES_FROM_WHITELIST');
-    }
-
-    private function getLinesToBeIgnored(string $fileName): array
-    {
-        if (isset($this->ignoredLines[$fileName])) {
-            return $this->ignoredLines[$fileName];
-        }
-
-        try {
-            return $this->getLinesToBeIgnoredInner($fileName);
-        } catch (\OutOfBoundsException $e) {
-            // This can happen with PHP_Token_Stream if the file is syntactically invalid,
-            // and probably affects a file that wasn't executed.
-            return [];
-        }
-    }
-
-    private function getLinesToBeIgnoredInner(string $fileName): array
-    {
-        $this->ignoredLines[$fileName] = [];
-
-        $lines = \file($fileName);
-
-        foreach ($lines as $index => $line) {
-            if (!\trim($line)) {
-                $this->ignoredLines[$fileName][] = $index + 1;
-            }
-        }
-
-        if ($this->cacheTokens) {
-            $tokens = \PHP_Token_Stream_CachingFactory::get($fileName);
-        } else {
-            $tokens = new \PHP_Token_Stream($fileName);
-        }
-
-        foreach ($tokens->getInterfaces() as $interface) {
-            $interfaceStartLine = $interface['startLine'];
-            $interfaceEndLine   = $interface['endLine'];
-
-            foreach (\range($interfaceStartLine, $interfaceEndLine) as $line) {
-                $this->ignoredLines[$fileName][] = $line;
-            }
-        }
-
-        foreach (\array_merge($tokens->getClasses(), $tokens->getTraits()) as $classOrTrait) {
-            $classOrTraitStartLine = $classOrTrait['startLine'];
-            $classOrTraitEndLine   = $classOrTrait['endLine'];
-
-            if (empty($classOrTrait['methods'])) {
-                foreach (\range($classOrTraitStartLine, $classOrTraitEndLine) as $line) {
-                    $this->ignoredLines[$fileName][] = $line;
-                }
-
-                continue;
-            }
-
-            $firstMethod          = \array_shift($classOrTrait['methods']);
-            $firstMethodStartLine = $firstMethod['startLine'];
-            $firstMethodEndLine   = $firstMethod['endLine'];
-            $lastMethodEndLine    = $firstMethodEndLine;
-
-            do {
-                $lastMethod = \array_pop($classOrTrait['methods']);
-            } while ($lastMethod !== null && 0 === \strpos($lastMethod['signature'], 'anonymousFunction'));
-
-            if ($lastMethod !== null) {
-                $lastMethodEndLine = $lastMethod['endLine'];
-            }
-
-            foreach (\range($classOrTraitStartLine, $firstMethodStartLine) as $line) {
-                $this->ignoredLines[$fileName][] = $line;
-            }
-
-            foreach (\range($lastMethodEndLine + 1, $classOrTraitEndLine) as $line) {
-                $this->ignoredLines[$fileName][] = $line;
-            }
-        }
-
-        if ($this->disableIgnoredLines) {
-            $this->ignoredLines[$fileName] = \array_unique($this->ignoredLines[$fileName]);
-            \sort($this->ignoredLines[$fileName]);
-
-            return $this->ignoredLines[$fileName];
-        }
-
-        $ignore = false;
-        $stop   = false;
-
-        foreach ($tokens->tokens() as $token) {
-            switch (\get_class($token)) {
-                case \PHP_Token_COMMENT::class:
-                case \PHP_Token_DOC_COMMENT::class:
-                    $_token = \trim($token);
-                    $_line  = \trim($lines[$token->getLine() - 1]);
-
-                    if ($_token === '// @codeCoverageIgnore' ||
-                        $_token === '//@codeCoverageIgnore') {
-                        $ignore = true;
-                        $stop   = true;
-                    } elseif ($_token === '// @codeCoverageIgnoreStart' ||
-                        $_token === '//@codeCoverageIgnoreStart') {
-                        $ignore = true;
-                    } elseif ($_token === '// @codeCoverageIgnoreEnd' ||
-                        $_token === '//@codeCoverageIgnoreEnd') {
-                        $stop = true;
-                    }
-
-                    if (!$ignore) {
-                        $start = $token->getLine();
-                        $end   = $start + \substr_count($token, "\n");
-
-                        // Do not ignore the first line when there is a token
-                        // before the comment
-                        if (0 !== \strpos($_token, $_line)) {
-                            $start++;
-                        }
-
-                        for ($i = $start; $i < $end; $i++) {
-                            $this->ignoredLines[$fileName][] = $i;
-                        }
-
-                        // A DOC_COMMENT token or a COMMENT token starting with "/*"
-                        // does not contain the final \n character in its text
-                        if (isset($lines[$i - 1]) && 0 === \strpos($_token, '/*') && '*/' === \substr(\trim($lines[$i - 1]), -2)) {
-                            $this->ignoredLines[$fileName][] = $i;
-                        }
-                    }
-
-                    break;
-
-                case \PHP_Token_INTERFACE::class:
-                case \PHP_Token_TRAIT::class:
-                case \PHP_Token_CLASS::class:
-                case \PHP_Token_FUNCTION::class:
-                    /* @var \PHP_Token_Interface $token */
-
-                    $docblock = $token->getDocblock();
-
-                    $this->ignoredLines[$fileName][] = $token->getLine();
-
-                    if (\strpos($docblock, '@codeCoverageIgnore') || ($this->ignoreDeprecatedCode && \strpos($docblock, '@deprecated'))) {
-                        $endLine = $token->getEndLine();
-
-                        for ($i = $token->getLine(); $i <= $endLine; $i++) {
-                            $this->ignoredLines[$fileName][] = $i;
-                        }
-                    }
-
-                    break;
-
-                /* @noinspection PhpMissingBreakStatementInspection */
-                case \PHP_Token_NAMESPACE::class:
-                    $this->ignoredLines[$fileName][] = $token->getEndLine();
-
-                // Intentional fallthrough
-                case \PHP_Token_DECLARE::class:
-                case \PHP_Token_OPEN_TAG::class:
-                case \PHP_Token_CLOSE_TAG::class:
-                case \PHP_Token_USE::class:
-                    $this->ignoredLines[$fileName][] = $token->getLine();
-
-                    break;
-            }
-
-            if ($ignore) {
-                $this->ignoredLines[$fileName][] = $token->getLine();
-
-                if ($stop) {
-                    $ignore = false;
-                    $stop   = false;
-                }
-            }
-        }
-
-        $this->ignoredLines[$fileName][] = \count($lines) + 1;
-
-        $this->ignoredLines[$fileName] = \array_unique(
-            $this->ignoredLines[$fileName]
-        );
-
-        $this->ignoredLines[$fileName] = \array_unique($this->ignoredLines[$fileName]);
-        \sort($this->ignoredLines[$fileName]);
-
-        return $this->ignoredLines[$fileName];
     }
 
     /**
@@ -894,7 +717,7 @@ final class CodeCoverage
     /**
      * @throws RuntimeException
      */
-    private function selectDriver(Filter $filter): Driver
+    private function selectDriver(Sieve $filter): Driver
     {
         $runtime = new Runtime;
 
@@ -955,16 +778,14 @@ final class CodeCoverage
             $this->shouldCheckForDeadAndUnused = false;
 
             $this->driver->start();
-
             foreach ($this->filter->getWhitelist() as $file) {
                 if ($this->filter->isFile($file)) {
-                    include_once $file;
+                    ($this->evaluateWhitelistedFile)($file);
                 }
             }
-
-            $data     = [];
             $coverage = $this->driver->stop();
 
+            $data     = [];
             foreach ($coverage as $file => $lines) {
                 if ($this->filter->isFiltered($file)) {
                     continue;

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -530,7 +530,7 @@ final class CodeCoverage
 
         $data = \array_intersect_key($data, $linesToBeCovered);
 
-        foreach (\array_keys($data) as $filename) {
+        foreach ((array)$data as $filename => $void) {
             $_linesToBeCovered = \array_flip($linesToBeCovered[$filename]);
             $data[$filename]   = \array_intersect_key($data[$filename], $_linesToBeCovered);
         }
@@ -538,7 +538,7 @@ final class CodeCoverage
 
     private function applyWhitelistFilter(array &$data): void
     {
-        foreach (\array_keys($data) as $filename) {
+        foreach ((array)$data as $filename => $void) {
             if ($this->filter->isFiltered($filename)) {
                 unset($data[$filename]);
             }
@@ -550,7 +550,7 @@ final class CodeCoverage
      */
     private function applyIgnoredLinesFilter(array &$data): void
     {
-        foreach (\array_keys($data) as $filename) {
+        foreach ((array)$data as $filename => $void) {
             if (!$this->filter->isFile($filename)) {
                 continue;
             }

--- a/src/Driver/Xdebug.php
+++ b/src/Driver/Xdebug.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\CodeCoverage\Driver;
 
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\RuntimeException;
+use SebastianBergmann\CodeCoverage\Sieve;
 
 /**
  * Driver for Xdebug's code coverage functionality.
@@ -25,14 +26,14 @@ final class Xdebug implements Driver
     private $cacheNumLines = [];
 
     /**
-     * @var Filter
+     * @var Sieve
      */
     private $filter;
 
     /**
      * @throws RuntimeException
      */
-    public function __construct(Filter $filter = null)
+    public function __construct(Sieve $filter = null)
     {
         if (!\extension_loaded('xdebug')) {
             throw new RuntimeException('This driver requires Xdebug');

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -14,7 +14,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 /**
  * Filter for whitelisting of code coverage information.
  */
-final class Filter
+final class Filter implements Sieve
 {
     /**
      * Source files that are whitelisted.
@@ -30,9 +30,7 @@ final class Filter
      */
     private $isFileCallsCache = [];
 
-    /**
-     * Adds a directory to the whitelist (recursively).
-     */
+    /** @inheritDoc */
     public function addDirectoryToWhitelist(string $directory, string $suffix = '.php', string $prefix = ''): void
     {
         $facade = new FileIteratorFacade;
@@ -43,19 +41,13 @@ final class Filter
         }
     }
 
-    /**
-     * Adds a file to the whitelist.
-     */
+    /** @inheritDoc */
     public function addFileToWhitelist(string $filename): void
     {
         $this->whitelistedFiles[\realpath($filename)] = true;
     }
 
-    /**
-     * Adds files to the whitelist.
-     *
-     * @param string[] $files
-     */
+    /** @inheritDoc */
     public function addFilesToWhitelist(array $files): void
     {
         foreach ($files as $file) {
@@ -63,9 +55,7 @@ final class Filter
         }
     }
 
-    /**
-     * Removes a directory from the whitelist (recursively).
-     */
+    /** @inheritDoc */
     public function removeDirectoryFromWhitelist(string $directory, string $suffix = '.php', string $prefix = ''): void
     {
         $facade = new FileIteratorFacade;
@@ -76,9 +66,7 @@ final class Filter
         }
     }
 
-    /**
-     * Removes a file from the whitelist.
-     */
+    /** @inheritDoc */
     public function removeFileFromWhitelist(string $filename): void
     {
         $filename = \realpath($filename);
@@ -86,9 +74,7 @@ final class Filter
         unset($this->whitelistedFiles[$filename]);
     }
 
-    /**
-     * Checks whether a filename is a real filename.
-     */
+    /** @inheritDoc */
     public function isFile(string $filename): bool
     {
         if (isset($this->isFileCallsCache[$filename])) {
@@ -114,9 +100,7 @@ final class Filter
         return $isFile;
     }
 
-    /**
-     * Checks whether or not a file is filtered.
-     */
+    /** @inheritDoc */
     public function isFiltered(string $filename): bool
     {
         if (!$this->isFile($filename)) {
@@ -126,37 +110,25 @@ final class Filter
         return !isset($this->whitelistedFiles[$filename]);
     }
 
-    /**
-     * Returns the list of whitelisted files.
-     *
-     * @return string[]
-     */
+    /** @inheritDoc */
     public function getWhitelist(): array
     {
         return \array_keys($this->whitelistedFiles);
     }
 
-    /**
-     * Returns whether this filter has a whitelist.
-     */
+    /** @inheritDoc */
     public function hasWhitelist(): bool
     {
         return !empty($this->whitelistedFiles);
     }
 
-    /**
-     * Returns the whitelisted files.
-     *
-     * @return string[]
-     */
+    /** @inheritDoc */
     public function getWhitelistedFiles(): array
     {
         return $this->whitelistedFiles;
     }
 
-    /**
-     * Sets the whitelisted files.
-     */
+    /** @inheritDoc */
     public function setWhitelistedFiles(array $whitelistedFiles): void
     {
         $this->whitelistedFiles = $whitelistedFiles;

--- a/src/LineFilter.php
+++ b/src/LineFilter.php
@@ -1,0 +1,247 @@
+<?php
+/*
+ * This file is part of the php-code-coverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+class LineFilter implements LineSieve
+{
+    /**
+     * @var bool
+     */
+    private $cacheTokens = false;
+
+    /**
+     * @var bool
+     */
+    private $disableIgnoredLines = false;
+
+    /**
+     * @var bool
+     */
+    private $ignoreDeprecatedCode = false;
+
+    /**
+     * @var array
+     */
+    private $ignoredLines = [];
+
+    public function setCacheTokens(bool $flag): void
+    {
+        $this->cacheTokens = $flag;
+    }
+
+    public function getCacheTokens(): bool
+    {
+        return $this->cacheTokens;
+    }
+
+    public function setDisableIgnoredLines(bool $flag): void
+    {
+        $this->disableIgnoredLines = $flag;
+    }
+
+    public function getDisableIgnoredLines(): bool
+    {
+        return $this->disableIgnoredLines;
+    }
+
+    public function setIgnoreDeprecatedCode(bool $flag): void
+    {
+        $this->ignoreDeprecatedCode = $flag;
+    }
+
+    public function getIgnoreDeprecatedCode(): bool
+    {
+        return $this->ignoreDeprecatedCode;
+    }
+
+    public function getLinesToBeIgnored(string $fileName): array
+    {
+        if (isset($this->ignoredLines[$fileName])) {
+            return $this->ignoredLines[$fileName];
+        }
+
+        try {
+            return $this->getLinesToBeIgnoredInner($fileName);
+        } catch (\OutOfBoundsException $e) {
+            // This can happen with PHP_Token_Stream if the file is syntactically invalid,
+            // and probably affects a file that wasn't executed.
+            return [];
+        }
+    }
+
+    private function getLinesToBeIgnoredInner(string $fileName): array
+    {
+        $this->ignoredLines[$fileName] = [];
+
+        $lines = \file($fileName);
+
+        foreach ($lines as $index => $line) {
+            if (!\trim($line)) {
+                $this->ignoredLines[$fileName][] = $index + 1;
+            }
+        }
+
+        if ($this->cacheTokens) {
+            $tokens = \PHP_Token_Stream_CachingFactory::get($fileName);
+        } else {
+            $tokens = new \PHP_Token_Stream($fileName);
+        }
+
+        foreach ($tokens->getInterfaces() as $interface) {
+            $interfaceStartLine = $interface['startLine'];
+            $interfaceEndLine   = $interface['endLine'];
+
+            foreach (\range($interfaceStartLine, $interfaceEndLine) as $line) {
+                $this->ignoredLines[$fileName][] = $line;
+            }
+        }
+
+        foreach (\array_merge($tokens->getClasses(), $tokens->getTraits()) as $classOrTrait) {
+            $classOrTraitStartLine = $classOrTrait['startLine'];
+            $classOrTraitEndLine   = $classOrTrait['endLine'];
+
+            if (empty($classOrTrait['methods'])) {
+                foreach (\range($classOrTraitStartLine, $classOrTraitEndLine) as $line) {
+                    $this->ignoredLines[$fileName][] = $line;
+                }
+
+                continue;
+            }
+
+            $firstMethod          = \array_shift($classOrTrait['methods']);
+            $firstMethodStartLine = $firstMethod['startLine'];
+            $firstMethodEndLine   = $firstMethod['endLine'];
+            $lastMethodEndLine    = $firstMethodEndLine;
+
+            do {
+                $lastMethod = \array_pop($classOrTrait['methods']);
+            } while ($lastMethod !== null && 0 === \strpos($lastMethod['signature'], 'anonymousFunction'));
+
+            if ($lastMethod !== null) {
+                $lastMethodEndLine = $lastMethod['endLine'];
+            }
+
+            foreach (\range($classOrTraitStartLine, $firstMethodStartLine) as $line) {
+                $this->ignoredLines[$fileName][] = $line;
+            }
+
+            foreach (\range($lastMethodEndLine + 1, $classOrTraitEndLine) as $line) {
+                $this->ignoredLines[$fileName][] = $line;
+            }
+        }
+
+        if ($this->disableIgnoredLines) {
+            $this->ignoredLines[$fileName] = \array_unique($this->ignoredLines[$fileName]);
+            \sort($this->ignoredLines[$fileName]);
+
+            return $this->ignoredLines[$fileName];
+        }
+
+        $ignore = false;
+        $stop   = false;
+
+        foreach ($tokens->tokens() as $token) {
+            switch (\get_class($token)) {
+                case \PHP_Token_COMMENT::class:
+                case \PHP_Token_DOC_COMMENT::class:
+                    $_token = \trim($token);
+                    $_line  = \trim($lines[$token->getLine() - 1]);
+
+                    if ($_token === '// @codeCoverageIgnore' ||
+                        $_token === '//@codeCoverageIgnore') {
+                        $ignore = true;
+                        $stop   = true;
+                    } elseif ($_token === '// @codeCoverageIgnoreStart' ||
+                        $_token === '//@codeCoverageIgnoreStart') {
+                        $ignore = true;
+                    } elseif ($_token === '// @codeCoverageIgnoreEnd' ||
+                        $_token === '//@codeCoverageIgnoreEnd') {
+                        $stop = true;
+                    }
+
+                    if (!$ignore) {
+                        $start = $token->getLine();
+                        $end   = $start + \substr_count($token, "\n");
+
+                        // Do not ignore the first line when there is a token
+                        // before the comment
+                        if (0 !== \strpos($_token, $_line)) {
+                            $start++;
+                        }
+
+                        for ($i = $start; $i < $end; $i++) {
+                            $this->ignoredLines[$fileName][] = $i;
+                        }
+
+                        // A DOC_COMMENT token or a COMMENT token starting with "/*"
+                        // does not contain the final \n character in its text
+                        if (isset($lines[$i - 1]) && 0 === \strpos($_token, '/*') && '*/' === \substr(\trim($lines[$i - 1]), -2)) {
+                            $this->ignoredLines[$fileName][] = $i;
+                        }
+                    }
+
+                    break;
+
+                case \PHP_Token_INTERFACE::class:
+                case \PHP_Token_TRAIT::class:
+                case \PHP_Token_CLASS::class:
+                case \PHP_Token_FUNCTION::class:
+                    /* @var \PHP_Token_Interface $token */
+
+                    $docblock = $token->getDocblock();
+
+                    $this->ignoredLines[$fileName][] = $token->getLine();
+
+                    if (\strpos($docblock, '@codeCoverageIgnore') || ($this->ignoreDeprecatedCode && \strpos($docblock, '@deprecated'))) {
+                        $endLine = $token->getEndLine();
+
+                        for ($i = $token->getLine(); $i <= $endLine; $i++) {
+                            $this->ignoredLines[$fileName][] = $i;
+                        }
+                    }
+
+                    break;
+
+                /* @noinspection PhpMissingBreakStatementInspection */
+                case \PHP_Token_NAMESPACE::class:
+                    $this->ignoredLines[$fileName][] = $token->getEndLine();
+
+                // Intentional fallthrough
+                case \PHP_Token_DECLARE::class:
+                case \PHP_Token_OPEN_TAG::class:
+                case \PHP_Token_CLOSE_TAG::class:
+                case \PHP_Token_USE::class:
+                    $this->ignoredLines[$fileName][] = $token->getLine();
+
+                    break;
+            }
+
+            if ($ignore) {
+                $this->ignoredLines[$fileName][] = $token->getLine();
+
+                if ($stop) {
+                    $ignore = false;
+                    $stop   = false;
+                }
+            }
+        }
+
+        $this->ignoredLines[$fileName][] = \count($lines) + 1;
+
+        $this->ignoredLines[$fileName] = \array_unique(
+            $this->ignoredLines[$fileName]
+        );
+
+        $this->ignoredLines[$fileName] = \array_unique($this->ignoredLines[$fileName]);
+        \sort($this->ignoredLines[$fileName]);
+
+        return $this->ignoredLines[$fileName];
+    }
+}

--- a/src/LineSieve.php
+++ b/src/LineSieve.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the php-code-coverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+interface LineSieve
+{
+    public function setCacheTokens(bool $flag): void;
+
+    public function getCacheTokens(): bool;
+
+    public function setDisableIgnoredLines(bool $flag): void;
+
+    public function setIgnoreDeprecatedCode(bool $flag): void;
+
+    /**
+     * @return int[]
+     */
+    public function getLinesToBeIgnored(string $fileName): array;
+}

--- a/src/Sieve.php
+++ b/src/Sieve.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * This file is part of the php-code-coverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+/**
+ * Filter for whitelisting of code coverage information.
+ */
+interface Sieve
+{
+    /**
+     * Adds a directory to the whitelist (recursively).
+     */
+    public function addDirectoryToWhitelist(string $directory, string $suffix = '.php', string $prefix = ''): void;
+
+    /**
+     * Adds a file to the whitelist.
+     */
+    public function addFileToWhitelist(string $filename): void;
+
+    /**
+     * Adds files to the whitelist.
+     *
+     * @param string[] $files
+     */
+    public function addFilesToWhitelist(array $files): void;
+
+    /**
+     * Removes a directory from the whitelist (recursively).
+     */
+    public function removeDirectoryFromWhitelist(string $directory, string $suffix = '.php', string $prefix = ''): void;
+
+    /**
+     * Removes a file from the whitelist.
+     */
+    public function removeFileFromWhitelist(string $filename): void;
+
+    /**
+     * Checks whether a filename is a real filename.
+     */
+    public function isFile(string $filename): bool;
+
+    /**
+     * Checks whether or not a file is filtered.
+     */
+    public function isFiltered(string $filename): bool;
+
+    /**
+     * Returns the list of whitelisted files.
+     *
+     * @return string[]
+     */
+    public function getWhitelist(): array;
+
+    /**
+     * Returns whether this filter has a whitelist.
+     */
+    public function hasWhitelist(): bool;
+
+    /**
+     * Returns the whitelisted files.
+     *
+     * @return array<string, true>
+     */
+    public function getWhitelistedFiles(): array;
+
+    /**
+     * Sets the whitelisted files.
+     *
+     * @param array<string, true> $whitelistedFiles
+     */
+    public function setWhitelistedFiles(array $whitelistedFiles): void;
+}

--- a/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
+++ b/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
@@ -2,7 +2,7 @@
 <html lang="en">
  <head>
   <meta charset="UTF-8">
-  <title>Code Coverage for %s/source_with_ignore.php</title>
+  <title>Code Coverage for %s%esource_with_ignore.php</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href=".css/bootstrap.min.css" rel="stylesheet" type="text/css">
   <link href=".css/octicons.css" rel="stylesheet" type="text/css">

--- a/tests/tests/CodeCoverageTest.php
+++ b/tests/tests/CodeCoverageTest.php
@@ -120,11 +120,19 @@ class CodeCoverageTest extends TestCase
         $this->coverage->append([], null);
     }
 
+
     public function testSetCacheTokens()
     {
-        $this->coverage->setCacheTokens(true);
+        $lineFilter = new LineFilter();
+        $coverage = new CodeCoverage(null, null, null, $lineFilter);
 
-        $this->assertAttributeEquals(true, 'cacheTokens', $this->coverage);
+        $coverage->setCacheTokens(true);
+        self::assertSame(true, $coverage->getCacheTokens());
+        self::assertSame(true, $lineFilter->getCacheTokens());
+
+        $coverage->setCacheTokens(false);
+        self::assertSame(false, $coverage->getCacheTokens());
+        self::assertSame(false, $lineFilter->getCacheTokens());
     }
 
     public function testSetCheckForUnintentionallyCoveredCode()
@@ -195,13 +203,26 @@ class CodeCoverageTest extends TestCase
 
     public function testSetIgnoreDeprecatedCode()
     {
-        $this->coverage->setIgnoreDeprecatedCode(true);
+        $lineFilter = new LineFilter();
+        $coverage = new CodeCoverage(null, null, null, $lineFilter);
 
-        $this->assertAttributeEquals(
-            true,
-            'ignoreDeprecatedCode',
-            $this->coverage
-        );
+        $coverage->setIgnoreDeprecatedCode(true);
+        self::assertSame(true, $lineFilter->getIgnoreDeprecatedCode());
+
+        $coverage->setIgnoreDeprecatedCode(false);
+        self::assertSame(false, $lineFilter->getIgnoreDeprecatedCode());
+    }
+
+    public function testSetDisableIgnoredLines()
+    {
+        $lineFilter = new LineFilter();
+        $coverage = new CodeCoverage(null, null, null, $lineFilter);
+
+        $coverage->setDisableIgnoredLines(true);
+        self::assertSame(true, $lineFilter->getDisableIgnoredLines());
+
+        $coverage->setDisableIgnoredLines(false);
+        self::assertSame(false, $lineFilter->getDisableIgnoredLines());
     }
 
     public function testClear()
@@ -267,176 +288,6 @@ class CodeCoverageTest extends TestCase
         $this->assertEquals(
             $this->getExpectedDataArrayForBankAccount(),
             $coverage->getData()
-        );
-    }
-
-    public function testGetLinesToBeIgnored()
-    {
-        $this->assertEquals(
-            [
-                1,
-                3,
-                4,
-                5,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                30,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38
-            ],
-            $this->getLinesToBeIgnored()->invoke(
-                $this->coverage,
-                TEST_FILES_PATH . 'source_with_ignore.php'
-            )
-        );
-    }
-
-    public function testGetLinesToBeIgnored2()
-    {
-        $this->assertEquals(
-            [1, 5],
-            $this->getLinesToBeIgnored()->invoke(
-                $this->coverage,
-                TEST_FILES_PATH . 'source_without_ignore.php'
-            )
-        );
-    }
-
-    public function testGetLinesToBeIgnored3()
-    {
-        $this->assertEquals(
-            [
-                1,
-                2,
-                3,
-                4,
-                5,
-                8,
-                11,
-                15,
-                16,
-                19,
-                20
-            ],
-            $this->getLinesToBeIgnored()->invoke(
-                $this->coverage,
-                TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php'
-            )
-        );
-    }
-
-    public function testGetLinesToBeIgnoredOneLineAnnotations()
-    {
-        $this->assertEquals(
-            [
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                14,
-                15,
-                16,
-                18,
-                20,
-                21,
-                23,
-                24,
-                25,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                37
-            ],
-            $this->getLinesToBeIgnored()->invoke(
-                $this->coverage,
-                TEST_FILES_PATH . 'source_with_oneline_annotations.php'
-            )
-        );
-    }
-
-    /**
-     * @return \ReflectionMethod
-     */
-    private function getLinesToBeIgnored()
-    {
-        $getLinesToBeIgnored = new \ReflectionMethod(
-            'SebastianBergmann\CodeCoverage\CodeCoverage',
-            'getLinesToBeIgnored'
-        );
-
-        $getLinesToBeIgnored->setAccessible(true);
-
-        return $getLinesToBeIgnored;
-    }
-
-    public function testGetLinesToBeIgnoredWhenIgnoreIsDisabled()
-    {
-        $this->coverage->setDisableIgnoredLines(true);
-
-        $this->assertEquals(
-            [
-                7,
-                11,
-                12,
-                13,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                26,
-                27,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37
-            ],
-            $this->getLinesToBeIgnored()->invoke(
-                $this->coverage,
-                TEST_FILES_PATH . 'source_with_ignore.php'
-            )
         );
     }
 

--- a/tests/tests/CodeCoverageTest.php
+++ b/tests/tests/CodeCoverageTest.php
@@ -447,8 +447,8 @@ class CodeCoverageTest extends TestCase
 
         $data = [
             TEST_FILES_PATH . 'BankAccount.php' => [
-                29 => -1,
-                31 => -1
+                29 => Driver::LINE_NOT_EXECUTED,
+                31 => Driver::LINE_NOT_EXECUTED
             ]
         ];
 
@@ -473,8 +473,8 @@ class CodeCoverageTest extends TestCase
 
         $data = [
             TEST_FILES_PATH . 'BankAccount.php' => [
-                29 => -1,
-                31 => -1
+                29 => Driver::LINE_NOT_EXECUTED,
+                31 => Driver::LINE_NOT_EXECUTED
             ]
         ];
 

--- a/tests/tests/LineFilterTest.php
+++ b/tests/tests/LineFilterTest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * This file is part of the php-code-coverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\CodeCoverage;
+
+/**
+ * @covers SebastianBergmann\CodeCoverage\LineFilter
+ */
+class LineFilterTest extends TestCase
+{
+    /**
+     * @var LineFilter
+     */
+    private $lineFilter;
+
+    protected function setUp()
+    {
+        $this->lineFilter = new LineFilter();
+    }
+
+    public function testSetCacheTokens()
+    {
+        $this->lineFilter->setCacheTokens(true);
+        self::assertSame(true, $this->lineFilter->getCacheTokens());
+        $this->lineFilter->setCacheTokens(false);
+        self::assertSame(false, $this->lineFilter->getCacheTokens());
+    }
+
+    public function testSetIgnoreDeprecatedCode()
+    {
+        $this->lineFilter->setIgnoreDeprecatedCode(true);
+        self::assertSame(true, $this->lineFilter->getIgnoreDeprecatedCode());
+        $this->lineFilter->setIgnoreDeprecatedCode(false);
+        self::assertSame(false, $this->lineFilter->getIgnoreDeprecatedCode());
+    }
+
+    public function testSetDisableIgnoredLines()
+    {
+        $this->lineFilter->setDisableIgnoredLines(true);
+        self::assertSame(true, $this->lineFilter->getDisableIgnoredLines());
+        $this->lineFilter->setDisableIgnoredLines(false);
+        self::assertSame(false, $this->lineFilter->getDisableIgnoredLines());
+    }
+
+    public function testGetLinesToBeIgnored()
+    {
+        $allLines = range(1, 38);
+        $executableLines = [2, 6, 29, 31];
+        $linesToBeIgnored = \array_values(\array_diff($allLines, $executableLines));
+
+        $actualLinesToBeIgnored = $this->lineFilter->getLinesToBeIgnored(
+            TEST_FILES_PATH . 'source_with_ignore.php'
+        );
+
+        self::assertSame($linesToBeIgnored, $actualLinesToBeIgnored);
+    }
+
+    public function testGetLinesToBeIgnored2()
+    {
+        $actualLinesToBeIgnored = $this->lineFilter->getLinesToBeIgnored(
+            TEST_FILES_PATH . 'source_without_ignore.php'
+        );
+
+        self::assertSame([1, 5], $actualLinesToBeIgnored);
+    }
+
+    public function testGetLinesToBeIgnored3()
+    {
+        $allLines = range(1, 20);
+        $executableLines = [6, 7, 9, 10, 12, 13, 14, 17, 18];
+        $linesToBeIgnored = \array_values(\array_diff($allLines, $executableLines));
+
+        $actualLinesToBeIgnored = $this->lineFilter->getLinesToBeIgnored(
+            TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php'
+        );
+
+        self::assertSame($linesToBeIgnored, $actualLinesToBeIgnored);
+    }
+
+    public function testGetLinesToBeIgnoredOneLineAnnotations()
+    {
+        $allLines = range(1, 37);
+        $executableLines = [12, 13, 17, 19, 22, 26, 35, 36];
+        $linesToBeIgnored = \array_values(\array_diff($allLines, $executableLines));
+
+        $actualLinesToBeIgnored = $this->lineFilter->getLinesToBeIgnored(
+            TEST_FILES_PATH . 'source_with_oneline_annotations.php'
+        );
+
+        self::assertSame($linesToBeIgnored, $actualLinesToBeIgnored);
+    }
+
+    public function testGetLinesToBeIgnoredWhenIgnoreIsDisabled()
+    {
+        $this->lineFilter->setDisableIgnoredLines(true);
+
+        $allLines = range(1, 38);
+        $executableLines = [1,2,3,4,5,6,8,9,10,14,15,24,25,28,29,30,31,38];
+        $linesToBeIgnored = \array_values(\array_diff($allLines, $executableLines));
+
+        $actualLinesToBeIgnored = $this->lineFilter->getLinesToBeIgnored(
+            TEST_FILES_PATH . 'source_with_ignore.php'
+        );
+
+        self::assertSame($linesToBeIgnored, $actualLinesToBeIgnored);
+    }
+}


### PR DESCRIPTION
This depends on the other PR I opened. I figured opening the PR now will give you more time to review it.

As per commit:

- add the interface `Sieve` matching the original `Filter`'s interface

- move line filtering functionality into their own class, `LineFilter`, which implements the interface `LineSieve`
- move the tests for line filtering to `LineFilterTest` (tests are also reformatted a bit)
- the public interface is 100% preserved, existing methods delegate to `$this->lineFilter->*` functions, which are essentially the same.

- abstraction for include_once() in initializeData()