### PR TITLE
Use monospace font stack

### DIFF
--- a/src/Report/Html/Renderer/Template/css/style.css
+++ b/src/Report/Html/Renderer/Template/css/style.css
@@ -64,7 +64,7 @@ td.small {
 }
 
 td.codeLine {
- font-family: monospace;
+ font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
  white-space: pre;
 }
 


### PR DESCRIPTION
Bootstrap 4 has a monospace font stack which is nicer than the generic `monospace` family name.
It will select the system fonts by default for macOS, Windows and Linux, and then fall back to `monospace`.
Using system fonts is a good practice, also GitHub uses a similar font stack in their CSS for displaying code.

Currently the `monospace` fallbacks to Courier which is visually much smaller than the sans-serif font-family used in Bootstrap 4 (at least on macOS).
![coverage-courier](https://user-images.githubusercontent.com/667144/47609075-f64fff00-da40-11e8-9d46-5f7e2f189e9d.png)

Here is the same snippet using Menlo
![coverage-menlo](https://user-images.githubusercontent.com/667144/47609076-f64fff00-da40-11e8-90e2-cb562393ef74.png)

And using SF Mono in recent macOS versions
![coverage-sf-mono](https://user-images.githubusercontent.com/667144/47609077-f6e89580-da40-11e8-8ed5-26fc575c7c35.png)

The font stack is defined here: https://github.com/twbs/bootstrap/blob/v4.1.3/scss/_variables.scss#L252