### PR TITLE
Use fluid layout for HTML file report

### DIFF
--- a/src/Report/Html/Renderer/Template/file.html.dist
+++ b/src/Report/Html/Renderer/Template/file.html.dist
@@ -11,7 +11,7 @@
  </head>
  <body>
   <header>
-   <div class="container">
+   <div class="container-fluid">
     <div class="row">
      <div class="col-md-12">
       <nav aria-label="breadcrumb">
@@ -23,8 +23,8 @@
     </div>
    </div>
   </header>
-  <div class="container">
-   <div class="table-responsive-md">
+  <div class="container-fluid">
+   <div class="table-responsive">
     <table class="table table-bordered">
      <thead>
       <tr>

--- a/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
+++ b/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
@@ -11,7 +11,7 @@
  </head>
  <body>
   <header>
-   <div class="container">
+   <div class="container-fluid">
     <div class="row">
      <div class="col-md-12">
       <nav aria-label="breadcrumb">
@@ -25,8 +25,8 @@
     </div>
    </div>
   </header>
-  <div class="container">
-   <div class="table-responsive-md">
+  <div class="container-fluid">
+   <div class="table-responsive">
     <table class="table table-bordered">
      <thead>
       <tr>

--- a/tests/_files/Report/HTML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.html
+++ b/tests/_files/Report/HTML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.html
@@ -11,7 +11,7 @@
  </head>
  <body>
   <header>
-   <div class="container">
+   <div class="container-fluid">
     <div class="row">
      <div class="col-md-12">
       <nav aria-label="breadcrumb">
@@ -25,8 +25,8 @@
     </div>
    </div>
   </header>
-  <div class="container">
-   <div class="table-responsive-md">
+  <div class="container-fluid">
+   <div class="table-responsive">
     <table class="table table-bordered">
      <thead>
       <tr>

--- a/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
+++ b/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
@@ -11,7 +11,7 @@
  </head>
  <body>
   <header>
-   <div class="container">
+   <div class="container-fluid">
     <div class="row">
      <div class="col-md-12">
       <nav aria-label="breadcrumb">
@@ -25,8 +25,8 @@
     </div>
    </div>
   </header>
-  <div class="container">
-   <div class="table-responsive-md">
+  <div class="container-fluid">
+   <div class="table-responsive">
     <table class="table table-bordered">
      <thead>
       <tr>


### PR DESCRIPTION
Possible fix for https://github.com/sebastianbergmann/php-code-coverage/issues/650

Table at the top stays within the viewport, but the code is allowed to flow out of it:
![screenshot from 2018-10-31 15-36-37](https://user-images.githubusercontent.com/1059790/47798868-6d2f1580-dd29-11e8-9e45-a02784ef7d71.png)


When the viewport gets smaller the table at the top gets a vertical scrollbar, but the code stays the same:
![screenshot from 2018-10-31 15-37-10](https://user-images.githubusercontent.com/1059790/47798874-6ef8d900-dd29-11e8-9b07-0da177b9b335.png)
