### PR TITLE
Issue #654: Copy assets to underscored directories

### DIFF
--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -118,7 +118,7 @@ final class Facade
      */
     private function copyFiles(string $target): void
     {
-        $dir = $this->getDirectory($target . '.css');
+        $dir = $this->getDirectory($target . '_css');
 
         \copy($this->templatePath . 'css/bootstrap.min.css', $dir . 'bootstrap.min.css');
         \copy($this->templatePath . 'css/nv.d3.min.css', $dir . 'nv.d3.min.css');
@@ -126,11 +126,11 @@ final class Facade
         \copy($this->templatePath . 'css/custom.css', $dir . 'custom.css');
         \copy($this->templatePath . 'css/octicons.css', $dir . 'octicons.css');
 
-        $dir = $this->getDirectory($target . '.icons');
+        $dir = $this->getDirectory($target . '_icons');
         \copy($this->templatePath . 'icons/file-code.svg', $dir . 'file-code.svg');
         \copy($this->templatePath . 'icons/file-directory.svg', $dir . 'file-directory.svg');
 
-        $dir = $this->getDirectory($target . '.js');
+        $dir = $this->getDirectory($target . '_js');
         \copy($this->templatePath . 'js/bootstrap.min.js', $dir . 'bootstrap.min.js');
         \copy($this->templatePath . 'js/popper.min.js', $dir . 'popper.min.js');
         \copy($this->templatePath . 'js/d3.min.js', $dir . 'd3.min.js');

--- a/src/Report/Html/Renderer/Directory.php
+++ b/src/Report/Html/Renderer/Directory.php
@@ -76,7 +76,7 @@ final class Directory extends Renderer
 
                 $up = \str_repeat('../', \count($node->getPathAsArray()) - 2);
 
-                $data['icon'] = \sprintf('<img src="%s.icons/file-directory.svg" class="octicon" />', $up);
+                $data['icon'] = \sprintf('<img src="%s_icons/file-directory.svg" class="octicon" />', $up);
             } else {
                 $data['name'] = \sprintf(
                     '<a href="%s.html">%s</a>',
@@ -86,7 +86,7 @@ final class Directory extends Renderer
 
                 $up = \str_repeat('../', \count($node->getPathAsArray()) - 2);
 
-                $data['icon'] = \sprintf('<img src="%s.icons/file-code.svg" class="octicon" />', $up);
+                $data['icon'] = \sprintf('<img src="%s_icons/file-code.svg" class="octicon" />', $up);
             }
         }
 

--- a/src/Report/Html/Renderer/Template/dashboard.html.dist
+++ b/src/Report/Html/Renderer/Template/dashboard.html.dist
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <title>Dashboard for {{full_path}}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="{{path_to_root}}.css/bootstrap.min.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/nv.d3.min.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/style.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/custom.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/bootstrap.min.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/nv.d3.min.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/style.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/custom.css" rel="stylesheet" type="text/css">
  </head>
  <body>
   <header>
@@ -137,9 +137,9 @@
     </p>
    </footer>
   </div>
-  <script src="{{path_to_root}}.js/jquery.min.js" type="text/javascript"></script>
-  <script src="{{path_to_root}}.js/d3.min.js" type="text/javascript"></script>
-  <script src="{{path_to_root}}.js/nv.d3.min.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/jquery.min.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/d3.min.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/nv.d3.min.js" type="text/javascript"></script>
   <script type="text/javascript">
 $(document).ready(function() {
   nv.addGraph(function() {

--- a/src/Report/Html/Renderer/Template/directory.html.dist
+++ b/src/Report/Html/Renderer/Template/directory.html.dist
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <title>Code Coverage for {{full_path}}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="{{path_to_root}}.css/bootstrap.min.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/octicons.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/style.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/custom.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/bootstrap.min.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/octicons.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/style.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/custom.css" rel="stylesheet" type="text/css">
  </head>
  <body>
   <header>

--- a/src/Report/Html/Renderer/Template/file.html.dist
+++ b/src/Report/Html/Renderer/Template/file.html.dist
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <title>Code Coverage for {{full_path}}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="{{path_to_root}}.css/bootstrap.min.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/octicons.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/style.css" rel="stylesheet" type="text/css">
-  <link href="{{path_to_root}}.css/custom.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/bootstrap.min.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/octicons.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/style.css" rel="stylesheet" type="text/css">
+  <link href="{{path_to_root}}_css/custom.css" rel="stylesheet" type="text/css">
  </head>
  <body>
   <header>
@@ -64,9 +64,9 @@
     </a>
    </footer>
   </div>
-  <script src="{{path_to_root}}.js/jquery.min.js" type="text/javascript"></script>
-  <script src="{{path_to_root}}.js/popper.min.js" type="text/javascript"></script>
-  <script src="{{path_to_root}}.js/bootstrap.min.js" type="text/javascript"></script>
-  <script src="{{path_to_root}}.js/file.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/jquery.min.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/popper.min.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/bootstrap.min.js" type="text/javascript"></script>
+  <script src="{{path_to_root}}_js/file.js" type="text/javascript"></script>
  </body>
 </html>


### PR DESCRIPTION
Move assets to underscored instead of hidden directories to prevent issues with with apache access when strict mimetype checking is enabled.