### PR TITLE
Do not suggest xdebug extension anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,6 @@
     "require-dev": {
         "phpunit/phpunit": "^8.0"
     },
-    "suggest": {
-        "ext-xdebug": "^2.6.1"
-    },
     "autoload": {
         "classmap": [
             "src/"


### PR DESCRIPTION
The suggestion seems biased, e.g. we use pcov now for code coverage which works perfectly fine and is several times faster compared to xdebug.