### PR TITLE
Throw RuntimeException from CodeCoverage namespace

### DIFF
--- a/src/Report/Clover.php
+++ b/src/Report/Clover.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report;
 
+use PHPUnit\Framework\Error\Warning;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Node\File;
 use SebastianBergmann\CodeCoverage\RuntimeException;
@@ -19,7 +20,7 @@ use SebastianBergmann\CodeCoverage\RuntimeException;
 final class Clover
 {
     /**
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function process(CodeCoverage $coverage, ?string $target = null, ?string $name = null): string
     {
@@ -235,13 +236,13 @@ final class Clover
 
         if ($target !== null) {
             if (!$this->createDirectory(\dirname($target))) {
-                throw new \RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
+                throw new RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
             }
 
             if (@\file_put_contents($target, $buffer) === false) {
                 throw new RuntimeException(
                     \sprintf(
-                        'Could not write to "%s',
+                        'Could not write to "%s"',
                         $target
                     )
                 );
@@ -253,6 +254,10 @@ final class Clover
 
     private function createDirectory(string $directory): bool
     {
-        return !(!\is_dir($directory) && !@\mkdir($directory, 0777, true) && !\is_dir($directory));
+        try {
+            return !(!\is_dir($directory) && !\mkdir($directory, 0777, true) && !\is_dir($directory));
+        } catch (Warning $warning) {
+            return false;
+        }
     }
 }

--- a/src/Report/Crap4j.php
+++ b/src/Report/Crap4j.php
@@ -26,7 +26,7 @@ final class Crap4j
     }
 
     /**
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function process(CodeCoverage $coverage, ?string $target = null, ?string $name = null): string
     {
@@ -117,13 +117,13 @@ final class Crap4j
 
         if ($target !== null) {
             if (!$this->createDirectory(\dirname($target))) {
-                throw new \RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
+                throw new RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
             }
 
             if (@\file_put_contents($target, $buffer) === false) {
                 throw new RuntimeException(
                     \sprintf(
-                        'Could not write to "%s',
+                        'Could not write to "%s"',
                         $target
                     )
                 );

--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -49,7 +49,6 @@ final class Facade
     /**
      * @throws RuntimeException
      * @throws \InvalidArgumentException
-     * @throws \RuntimeException
      */
     public function process(CodeCoverage $coverage, string $target): void
     {
@@ -94,7 +93,7 @@ final class Facade
 
             if ($node instanceof DirectoryNode) {
                 if (!$this->createDirectory($target . $id)) {
-                    throw new \RuntimeException(\sprintf('Directory "%s" was not created', $target . $id));
+                    throw new RuntimeException(\sprintf('Directory "%s" was not created', $target . $id));
                 }
 
                 $directory->render($node, $target . $id . '/index.html');
@@ -103,7 +102,7 @@ final class Facade
                 $dir = \dirname($target . $id);
 
                 if (!$this->createDirectory($dir)) {
-                    throw new \RuntimeException(\sprintf('Directory "%s" was not created', $dir));
+                    throw new RuntimeException(\sprintf('Directory "%s" was not created', $dir));
                 }
 
                 $file->render($node, $target . $id . '.html');

--- a/src/Report/PHP.php
+++ b/src/Report/PHP.php
@@ -18,7 +18,7 @@ use SebastianBergmann\CodeCoverage\RuntimeException;
 final class PHP
 {
     /**
-     * @throws \SebastianBergmann\CodeCoverage\RuntimeException
+     * @throws RuntimeException
      */
     public function process(CodeCoverage $coverage, ?string $target = null): string
     {
@@ -41,13 +41,13 @@ return $coverage;',
 
         if ($target !== null) {
             if (!$this->createDirectory(\dirname($target))) {
-                throw new \RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
+                throw new RuntimeException(\sprintf('Directory "%s" was not created', \dirname($target)));
             }
 
             if (@\file_put_contents($target, $buffer) === false) {
                 throw new RuntimeException(
                     \sprintf(
-                        'Could not write to "%s',
+                        'Could not write to "%s"',
                         $target
                     )
                 );

--- a/tests/_files/BankAccount.php.txt
+++ b/tests/_files/BankAccount.php.txt
@@ -1,0 +1,77 @@
+<?php
+$coverage = new SebastianBergmann\CodeCoverage\CodeCoverage;
+$coverage->setData(array (
+  '%s%etests/_files/BankAccount.php' => 
+  array (
+    8 => 
+    array (
+      0 => 'BankAccountTest::testBalanceIsInitiallyZero',
+      1 => 'BankAccountTest::testDepositWithdrawMoney',
+    ),
+    9 => NULL,
+    13 => 
+    array (
+    ),
+    14 => 
+    array (
+    ),
+    15 => 
+    array (
+    ),
+    16 => 
+    array (
+    ),
+    18 => 
+    array (
+    ),
+    22 => 
+    array (
+      0 => 'BankAccountTest::testBalanceCannotBecomeNegative2',
+      1 => 'BankAccountTest::testDepositWithdrawMoney',
+    ),
+    24 => 
+    array (
+      0 => 'BankAccountTest::testDepositWithdrawMoney',
+    ),
+    25 => NULL,
+    29 => 
+    array (
+      0 => 'BankAccountTest::testBalanceCannotBecomeNegative',
+      1 => 'BankAccountTest::testDepositWithdrawMoney',
+    ),
+    31 => 
+    array (
+      0 => 'BankAccountTest::testDepositWithdrawMoney',
+    ),
+    32 => NULL,
+  ),
+));
+$coverage->setTests(array (
+  'BankAccountTest::testBalanceIsInitiallyZero' => 
+  array (
+    'size' => 'unknown',
+    'status' => -1,
+  ),
+  'BankAccountTest::testBalanceCannotBecomeNegative' => 
+  array (
+    'size' => 'unknown',
+    'status' => -1,
+  ),
+  'BankAccountTest::testBalanceCannotBecomeNegative2' => 
+  array (
+    'size' => 'unknown',
+    'status' => -1,
+  ),
+  'BankAccountTest::testDepositWithdrawMoney' => 
+  array (
+    'size' => 'unknown',
+    'status' => -1,
+  ),
+));
+
+$filter = $coverage->filter();
+$filter->setWhitelistedFiles(array (
+  '%s%etests/_files/BankAccount.php' => true,
+));
+
+return $coverage;

--- a/tests/tests/CloverTest.php
+++ b/tests/tests/CloverTest.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report;
 
+use SebastianBergmann\CodeCoverage\RuntimeException;
 use SebastianBergmann\CodeCoverage\TestCase;
 
 /**
@@ -44,5 +45,23 @@ class CloverTest extends TestCase
             TEST_FILES_PATH . 'class-with-anonymous-function-clover.xml',
             $clover->process($this->getCoverageForClassWithAnonymousFunction())
         );
+    }
+
+    public function testCloverThrowsRuntimeExceptionWhenUnableToWriteToTarget(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write to "stdout://"');
+
+        $clover = new Clover;
+        $clover->process($this->getCoverageForBankAccount(), 'stdout://');
+    }
+
+    public function testCloverThrowsRuntimeExceptionWhenTargetDirCouldNotBeCreated(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Directory "/foo/bar" was not created');
+
+        $clover = new Clover;
+        $clover->process($this->getCoverageForBankAccount(), '/foo/bar/baz');
     }
 }

--- a/tests/tests/Crap4jTest.php
+++ b/tests/tests/Crap4jTest.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report;
 
+use SebastianBergmann\CodeCoverage\RuntimeException;
 use SebastianBergmann\CodeCoverage\TestCase;
 
 /**
@@ -44,5 +45,23 @@ class Crap4jTest extends TestCase
             TEST_FILES_PATH . 'class-with-anonymous-function-crap4j.xml',
             $crap4j->process($this->getCoverageForClassWithAnonymousFunction(), null, 'CoverageForClassWithAnonymousFunction')
         );
+    }
+
+    public function testCrap4jThrowsRuntimeExceptionWhenUnableToWriteToTarget(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write to "stdout://"');
+
+        $Crap4j = new Crap4j;
+        $Crap4j->process($this->getCoverageForBankAccount(), 'stdout://');
+    }
+
+    public function testCrap4jThrowsRuntimeExceptionWhenTargetDirWasNotCreated(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Directory "/foo/bar" was not created');
+
+        $Crap4j = new Crap4j;
+        $Crap4j->process($this->getCoverageForBankAccount(), '/foo/bar/baz');
     }
 }

--- a/tests/tests/HTMLTest.php
+++ b/tests/tests/HTMLTest.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Html;
 
+use SebastianBergmann\CodeCoverage\RuntimeException;
 use SebastianBergmann\CodeCoverage\TestCase;
 
 class HTMLTest extends TestCase
@@ -67,6 +68,15 @@ class HTMLTest extends TestCase
         $report->process($this->getCoverageForClassWithAnonymousFunction(), self::$TEST_TMP_PATH);
 
         $this->assertFilesEquals($expectedFilesPath, self::$TEST_TMP_PATH);
+    }
+
+    public function testThrowsRuntimeExceptionWhenTargetDirDoesNotExist(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Directory "/foo/bar/baz/" does not exist.');
+
+        $report = new Facade();
+        $report->process($this->getCoverageForBankAccount(), '/foo/bar/baz');
     }
 
     /**

--- a/tests/tests/PHPTest.php
+++ b/tests/tests/PHPTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of the php-code-coverage package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Report;
+
+use SebastianBergmann\CodeCoverage\RuntimeException;
+use SebastianBergmann\CodeCoverage\TestCase;
+
+/**
+ * @covers SebastianBergmann\CodeCoverage\Report\PHP
+ */
+class PHPTest extends TestCase
+{
+    public function testPHPForBankAccountTest(): void
+    {
+        $report = new PHP();
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccount.php.txt',
+            \str_replace(\PHP_EOL, "\n", $report->process($this->getCoverageForBankAccount()))
+        );
+    }
+
+    public function testReportThrowsRuntimeExceptionWhenUnableToWriteToTarget(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write to "stdin://"');
+
+        $report = new PHP();
+        $report->process($this->getCoverageForBankAccount(), 'stdin://');
+    }
+
+    public function testReportThrowsRuntimeExceptionWhenTargetDirCouldNotBeCreated(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Directory "/foo/bar" was not created');
+
+        $report = new PHP();
+        $report->process($this->getCoverageForBankAccount(), '/foo/bar/baz');
+    }
+}


### PR DESCRIPTION
Psalm was erroring about exception types in some coverage report formats (in phpunit repo), traced that to here.

It looks like the use of `CodeCoverage\RuntimeException` and `\RuntimeException` is is mixed, making thrown exception types inconsistent.

This PR makes the exceptions consistent. I've touched some places without any coverage, so the changes contain a lot test stuff. Some report facades should now even be 100% covered.