### PR TITLE
Throw an exception if code coverage fails to write to disk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "require": {
         "php": "^7.3",
         "ext-dom": "*",
+        "ext-libxml": "*",
         "ext-xmlwriter": "*",
         "phpunit/php-file-iterator": "^3.0",
         "phpunit/php-token-stream": "^4.0",

--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -276,7 +276,24 @@ final class Facade
         $document->preserveWhiteSpace = false;
         $this->initTargetDirectory(\dirname($filename));
 
+        $original = \libxml_use_internal_errors(true);
+
         /* @see https://bugs.php.net/bug.php?id=79191 */
-        \file_put_contents($filename, $document->saveXML());
+        $xml = $document->saveXML();
+
+        if ($xml === false) {
+            $message = 'Unable to generate the XML';
+
+            foreach (\libxml_get_errors() as $error) {
+                $message .= "\n" . $error->message;
+            }
+
+            throw new RuntimeException($message);
+        }
+
+        \libxml_clear_errors();
+        \libxml_use_internal_errors($original);
+
+        \file_put_contents($filename, $xml);
     }
 }


### PR DESCRIPTION
I'm experiencing the same issue as #692 (seems to the `\SoapClient` causing some issues).

I traced the error to this `\DomDocument#save()` call.

This PR adds error checking to that call, so that at least the issue is reported.

### Before:
```
PHPUnit 8.3.5 by Sebastian Bergmann and contributors.
.                                                                   1 / 1 (100%)
Time: 46 ms, Memory: 6.00 MB
OK (1 test, 1 assertion)

Generating code coverage report in PHPUnit XML format ... done [8 ms]
```

### After:
```
PHPUnit 8.3.5 by Sebastian Bergmann and contributors.
.                                                                   1 / 1 (100%)
Time: 44 ms, Memory: 6.00 MB
OK (1 test, 1 assertion)

Generating code coverage report in PHPUnit XML format ... Unable to save the XML
flush error
```