### PR TITLE
replace hardcoded path delimiter with parameter in test

### DIFF
--- a/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
+++ b/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
@@ -2,7 +2,7 @@
 <html lang="en">
  <head>
   <meta charset="UTF-8">
-  <title>Code Coverage for %s/source_with_ignore.php</title>
+  <title>Code Coverage for %s%esource_with_ignore.php</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="_css/bootstrap.min.css" rel="stylesheet" type="text/css">
   <link href="_css/octicons.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
noticed the test was broken on a windows machine