### PR TITLE
Added missing Clover attributes

### DIFF
--- a/src/Report/Clover.php
+++ b/src/Report/Clover.php
@@ -50,7 +50,8 @@ final class Clover
             /* @var File $item */
 
             $xmlFile = $xmlDocument->createElement('file');
-            $xmlFile->setAttribute('name', $item->getPath());
+            $xmlFile->setAttribute('path', $item->getPath());
+            $xmlFile->setAttribute('name', $item->getName());
 
             $classes      = $item->getClassesAndTraits();
             $coverageData = $item->getCoverageData();


### PR DESCRIPTION
Generated XML files in _Clover_ format are missing some attributes compared to [OpenClover](http://openclover.org/).
This caused some issues for [ReportGenerator](https://github.com/danielpalme/ReportGenerator): [#292](https://github.com/danielpalme/ReportGenerator/issues/292)

This PR adds:
- The `path` attribute for `file` elements. See:
https://bitbucket.org/openclover/clover/src/f0bcec5c73690cc3caf56e6e66e17fc619d4a882/clover-core/src/main/java/com/atlassian/clover/reporters/xml/XMLReporter.java#lines-258
- The `signature` attribute for `line` elements. See:
https://bitbucket.org/openclover/clover/src/f0bcec5c73690cc3caf56e6e66e17fc619d4a882/clover-core/src/main/java/com/atlassian/clover/reporters/xml/XMLReporter.java#lines-303