### PR TITLE
Fix an impossible condition of float === 0 computing CRAP score

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -578,7 +578,7 @@ final class File extends AbstractNode
 
     private function crap(int $ccn, float $coverage): string
     {
-        if ($coverage === 0) {
+        if ($coverage === 0.0) {
             return (string) ($ccn ** 2 + $ccn);
         }
 

--- a/tests/_files/BankAccount-clover.xml
+++ b/tests/_files/BankAccount-clover.xml
@@ -7,7 +7,7 @@
       </class>
       <line num="6" type="method" name="getBalance" signature="getBalance" visibility="public" complexity="1" crap="1" count="2"/>
       <line num="8" type="stmt" count="2"/>
-      <line num="11" type="method" name="setBalance" signature="setBalance" visibility="protected" complexity="2" crap="6.00" count="0"/>
+      <line num="11" type="method" name="setBalance" signature="setBalance" visibility="protected" complexity="2" crap="6" count="0"/>
       <line num="13" type="stmt" count="0"/>
       <line num="14" type="stmt" count="0"/>
       <line num="15" type="stmt" count="0"/>

--- a/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
+++ b/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
@@ -130,7 +130,7 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
-       <td class="danger small">6.00</td>
+       <td class="danger small">6</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/XML/CoverageForBankAccount/BankAccount.php.xml
+++ b/tests/_files/Report/XML/CoverageForBankAccount/BankAccount.php.xml
@@ -12,7 +12,7 @@
       <package full="" name="" sub="" category=""/>
       <namespace name=""/>
       <method name="getBalance" signature="getBalance()" start="6" end="9" crap="1" executable="1" executed="1" coverage="100"/>
-      <method name="setBalance" signature="setBalance($balance)" start="11" end="18" crap="6.00" executable="5" executed="0" coverage="0"/>
+      <method name="setBalance" signature="setBalance($balance)" start="11" end="18" crap="6" executable="5" executed="0" coverage="0"/>
       <method name="depositMoney" signature="depositMoney($balance)" start="20" end="25" crap="1" executable="2" executed="2" coverage="100"/>
       <method name="withdrawMoney" signature="withdrawMoney($balance)" start="27" end="32" crap="1" executable="2" executed="2" coverage="100"/>
     </class>


### PR DESCRIPTION
In PHP, `0 === 0.0` is false.
Impact: slightly faster computation and rendering some results as integers instead of floats,

```
php > var_export(0 === 0.0);
false
```