### PR TITLE
Prioritize pcov above xdebug

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -896,12 +896,12 @@ final class CodeCoverage
             return new PHPDBG;
         }
 
-        if ($runtime->hasXdebug()) {
-            return new Xdebug($filter);
-        }
-
         if ($runtime->hasPCOV()) {
             return new PCOV;
+        }
+
+        if ($runtime->hasXdebug()) {
+            return new Xdebug($filter);
         }
 
         throw new RuntimeException('No code coverage driver available');


### PR DESCRIPTION
Pcov is a much faster code coverage driver and in situtation where both Xdebug and pcov are installed it should be used above xdebug in my opinion.

I've tested with a codebase with some 40k lines of code and 4000 tests.

| Config | Time | Memory |
| ------- | ---- | ---------|
| No coverage| 20s | 280MB|
| Pcov only | 42s | 390MB|
| Pcov and xdebug with patch | 1.44min | 410MB |
| Pcov and xdebug without patch | 8min | 360MB |

It is a change in behavior though as pcov and xdebug might collect different coverage information