### PR TITLE
Use saveXml() instead of save()

### DIFF
--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -277,7 +277,7 @@ final class Facade
         $document->preserveWhiteSpace = false;
         $this->initTargetDirectory(\dirname($filename));
 
-        $document->save($filename);
+        \file_put_contents($filename, $document->saveXML());
     }
 
     private function createDirectory(string $directory): bool


### PR DESCRIPTION
As reported in issue #692 there seems to be an issue writing the XML code coverage to disk when using the `\SoapClient` class. This PR gets around that issue by using `saveXml()` to generate the XML and the `file_put_contents()` to write it