### PR TITLE
Fix: Set up PHP with pcov for static code analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,27 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v2"
 
+      - name: "Install PHP with extensions"
+        uses: "shivammathur/setup-php@v1"
+        with:
+          php-version: "7.3"
+          coverage: "pcov"
+
+      - name: "Cache dependencies installed with composer"
+        uses: "actions/cache@v1"
+        with:
+          path: "~/.composer/cache"
+          key: "php7.3-composer-highest-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "php7.3-composer-highest-"
+
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
         uses: "docker://ergebnis/composer-root-version-action:0.1.3"
 
       - name: "Update dependencies with composer"
-        run: "php7.3 ./tools/composer update --no-ansi --no-interaction --no-progress --no-suggest"
+        run: "./tools/composer update --no-ansi --no-interaction --no-progress --no-suggest"
 
       - name: "Run vimeo/psalm"
-        run: "php7.3 ./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats"
+        run: "./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats"
 
   tests:
     name: "Tests"


### PR DESCRIPTION
This PR

* [x] sets up PHP with the `pcov` extension enabled for the static code analysis job