### PR TITLE
WIP: Add Cobertura report format

### DIFF
--- a/src/Report/Cobertura.php
+++ b/src/Report/Cobertura.php
@@ -1,0 +1,210 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Report;
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Node\Directory;
+use SebastianBergmann\CodeCoverage\Node\File;
+
+final class Cobertura
+{
+    /**
+     * Process coverage and generate a Cobertura report.
+     */
+    public function process(CodeCoverage $coverage, string $packageName): string
+    {
+        $document = $this->createBaseDocument();
+
+        $elClasses = $document->createElement('classes');
+
+        $coverageFiles = $coverage->getReport()->getFiles();
+
+        $validLineClasses   = 0;
+        $coveredLineClasses = 0;
+
+        /** @var File $file */
+        foreach ($coverageFiles as $file) {
+            if (!$file instanceof File) {
+                continue;
+            }
+
+            $coverageData    = $file->getCoverageData();
+            $coverageClasses = $file->getClassesAndTraits();
+            $currentFileName = $file->getPath();
+
+            foreach ($coverageClasses as $class) {
+                if (!empty($class['package']['namespace'])) {
+                    $namespace = $class['package']['namespace'];
+                    $className = $namespace . '\\' . $class['className'];
+                } else {
+                    $className = $class['className'];
+                }
+
+                $linesValid   = $class['executableLines'];
+                $linesCovered = $class['executedLines'];
+
+                $validLineClasses += $linesValid;
+                $coveredLineClasses += $linesCovered;
+
+                $classLineRate = $linesValid === 0 ? 0 : ($linesCovered / $linesValid);
+                $methods       = $document->createElement('methods');
+                $classLines    = $document->createElement('lines');
+                $coverageLines = $coverageData;
+
+                $elClass = $document->createElement('class');
+                $elClass->setAttribute('name', $className);
+                $elClass->setAttribute('complexity', (string) $class['ccn']);
+                $elClass->setAttribute('branch-rate', '0');
+                $elClass->setAttribute('line-rate', (string) $classLineRate);
+                $elClass->setAttribute('filename', $currentFileName);
+
+                if ($linesValid !== 0) {
+                    $classMethods = $class['methods'];
+                } else {
+                    $classMethods = []; // Nothing to cover, skip processing
+                }
+
+                foreach ($classMethods as $method) {
+                    $methodLinesStart = $method['startLine'];
+                    $methodLinesEnd   = $method['endLine'];
+
+                    $methodLinesValid    = $method['executableLines'];
+                    $methodLinesExecuted = $method['executedLines'];
+                    $methodLines         = $document->createElement('lines');
+
+                    foreach ($coverageLines as $lineNumber => $coveredBy) {
+                        if ($lineNumber < $methodLinesStart || $lineNumber >= $methodLinesEnd) {
+                            continue;
+                        }
+
+                        $lineHits = $coveredBy === null ? '0' : (string) \count($coveredBy);
+
+                        $elLine = $document->createElement('line');
+                        $elLine->setAttribute('number', (string) $lineNumber);
+                        $elLine->setAttribute('hits', $lineHits);
+
+                        $classLine = $elLine->cloneNode();
+
+                        $methodLines->appendChild($elLine);
+                        $classLines->appendChild($classLine);
+                    }
+
+                    $methodLineRate = 0;
+
+                    if ($methodLinesValid !== 0) {
+                        $methodLineRate = $methodLinesExecuted / $methodLinesValid;
+                    }
+
+                    $elMethod = $document->createElement('method');
+                    $elMethod->setAttribute('name', $method['methodName']);
+                    $elMethod->setAttribute('signature', $method['signature']);
+                    $elMethod->setAttribute('complexity', (string) $method['ccn']);
+                    $elMethod->setAttribute('branch-rate', '0');
+                    $elMethod->setAttribute('line-rate', (string) $methodLineRate);
+
+                    $elMethod->appendChild($methodLines);
+                    $methods->appendChild($elMethod);
+                }
+
+                $elClass->appendChild($methods);
+
+                $elClass->appendChild($classLines);
+
+                $elClasses->appendChild($elClass);
+            }
+        }
+
+        $report = $coverage->getReport();
+
+        $coveragePath = $report->getPath();
+
+        $combinedComplexity = $this->getCombinedComplexity($report);
+
+        $totalLineRate      = $validLineClasses === 0 ? 0 : ($coveredLineClasses / $validLineClasses);
+
+        $package = $document->createElement('package');
+        $package->setAttribute('name', $packageName);
+        $package->setAttribute('line-rate', (string) $totalLineRate);
+        $package->setAttribute('branch-rate', '0');
+        $package->setAttribute('complexity', (string) $combinedComplexity);
+
+        $package->appendChild($elClasses);
+
+        $elPackages = $document->createElement('packages');
+        $elPackages->appendChild($package);
+
+        $elSources = $document->createElement('sources');
+        $source    = $document->createElement('source', $coveragePath);
+        $elSources->appendChild($source);
+
+        $elCoverage = $document->createElement('coverage');
+        $elCoverage->setAttribute('lines-valid', (string) $validLineClasses);
+        $elCoverage->setAttribute('lines-covered', (string) $coveredLineClasses);
+        $elCoverage->setAttribute('line-rate', (string) $totalLineRate);
+
+        // The following are in place to please DTD validation
+        $elCoverage->setAttribute('branches-valid', '0');
+        $elCoverage->setAttribute('branches-covered', '0');
+        $elCoverage->setAttribute('branch-rate', '0');
+
+        $elCoverage->setAttribute('timestamp', (string) $_SERVER['REQUEST_TIME']);
+        $elCoverage->setAttribute('complexity', (string) $combinedComplexity);
+        $elCoverage->setAttribute('version', '0.1');
+
+        $elCoverage->appendChild($elSources);
+        $elCoverage->appendChild($elPackages);
+
+        $document->appendChild($elCoverage);
+
+        if ($document->validate() === false) {
+            throw new \RuntimeException('Could not generate Cobertura report, malformed report document generated');
+        }
+
+        $buffer = $document->saveXML();
+
+        return $buffer;
+    }
+
+    /**
+     * Create a base document for reporting.
+     */
+    private function createBaseDocument(): \DOMDocument
+    {
+        $impl = new \DOMImplementation();
+
+        $dtd = $impl->createDocumentType(
+            'coverage',
+            '',
+            'http://cobertura.sourceforge.net/xml/coverage-04.dtd'
+        );
+
+        $document                     = $impl->createDocument('', '', $dtd);
+        $document->xmlVersion         = '1.0';
+        $document->encoding           = 'UTF-8';
+        $document->formatOutput       = true;
+        $document->preserveWhiteSpace = false;
+
+        return $document;
+    }
+
+    /**
+     * Get combined code complexity for the coverage report.
+     */
+    private function getCombinedComplexity(Directory $report): int
+    {
+        $combined = 0;
+
+        foreach ($report->getClasses() as $class) {
+            $combined += (int) $class['ccn'];
+        }
+
+        return $combined;
+    }
+}

--- a/tests/_files/BankAccount-cobertura.xml
+++ b/tests/_files/BankAccount-cobertura.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="10" lines-covered="5" line-rate="0.5" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="%s" complexity="0" version="0.1">
+    <sources>
+        <source>%s</source>
+    </sources>
+    <packages>
+        <package name="BankAccount" line-rate="1" branch-rate="1" >
+            <classes>
+                <class name="BankAccount" filename="%sBankAccount.php" line-rate="1" branch-rate="1" >
+                    <methods>
+                        <method name="getBalance" hits="1" signature="()V">
+                            <lines>
+                                <line number="8"  hits="1"/>
+                            </lines>
+                        </method>
+                        <method name="setBalance" hits="0" signature="()V">
+                            <lines>
+                                <line number="13" hits="0"/>
+                                <line number="14" hits="0"/>
+                                <line number="15" hits="0"/>
+                                <line number="16" hits="0"/>
+                                <line number="17" hits="0"/>
+                            </lines>
+                        </method>
+                        <method name="depositMoney" hits="2" signature="()V">
+                            <lines>
+                                <line number="22" hits="1"/>
+                                <line number="24" hits="1"/>
+                            </lines>
+                        </method>
+                        <method name="withdrawMoney" hits="2" signature="()V">
+                            <lines>
+                                <line number="29" hits="1"/>
+                                <line number="31" hits="1"/>
+                            </lines>
+                        </method>
+                    </methods>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/tests/_files/BankAccount-cobertura.xml
+++ b/tests/_files/BankAccount-cobertura.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage lines-valid="10" lines-covered="5" line-rate="0.5" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="%s" complexity="0" version="0.1">
+<coverage lines-valid="10" lines-covered="5" line-rate="0.5" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="%s" complexity="5" version="0.1">
     <sources>
         <source>%s</source>
     </sources>
     <packages>
-        <package name="BankAccount" line-rate="1" branch-rate="1" >
+        <package name="BankAccount" line-rate="0.5" branch-rate="0">
             <classes>
-                <class name="BankAccount" filename="%sBankAccount.php" line-rate="1" branch-rate="1" >
+                <class name="BankAccount" filename="%sBankAccount.php" line-rate="1" branch-rate="1">
                     <methods>
                         <method name="getBalance" hits="2" signature="()V">
                             <lines>
@@ -37,15 +37,15 @@
                         </method>
                     </methods>
                     <lines>
-                        <line number="8" hits="1"/>
+                        <line number="8" hits="2"/>
                         <line number="13" hits="0"/>
                         <line number="14" hits="0"/>
                         <line number="15" hits="0"/>
                         <line number="16" hits="0"/>
                         <line number="17" hits="0"/>
-                        <line number="22" hits="1"/>
+                        <line number="22" hits="2"/>
                         <line number="24" hits="1"/>
-                        <line number="29" hits="1"/>
+                        <line number="29" hits="2"/>
                         <line number="31" hits="1"/>
                     </lines>
                 </class>

--- a/tests/_files/BankAccount-cobertura.xml
+++ b/tests/_files/BankAccount-cobertura.xml
@@ -9,9 +9,9 @@
             <classes>
                 <class name="BankAccount" filename="%sBankAccount.php" line-rate="1" branch-rate="1" >
                     <methods>
-                        <method name="getBalance" hits="1" signature="()V">
+                        <method name="getBalance" hits="2" signature="()V">
                             <lines>
-                                <line number="8"  hits="1"/>
+                                <line number="8" hits="2"/>
                             </lines>
                         </method>
                         <method name="setBalance" hits="0" signature="()V">
@@ -23,19 +23,31 @@
                                 <line number="17" hits="0"/>
                             </lines>
                         </method>
-                        <method name="depositMoney" hits="2" signature="()V">
+                        <method name="depositMoney" hits="3" signature="()V">
                             <lines>
-                                <line number="22" hits="1"/>
+                                <line number="22" hits="2"/>
                                 <line number="24" hits="1"/>
                             </lines>
                         </method>
-                        <method name="withdrawMoney" hits="2" signature="()V">
+                        <method name="withdrawMoney" hits="3" signature="()V">
                             <lines>
-                                <line number="29" hits="1"/>
+                                <line number="29" hits="2"/>
                                 <line number="31" hits="1"/>
                             </lines>
                         </method>
                     </methods>
+                    <lines>
+                        <line number="8" hits="1"/>
+                        <line number="13" hits="0"/>
+                        <line number="14" hits="0"/>
+                        <line number="15" hits="0"/>
+                        <line number="16" hits="0"/>
+                        <line number="17" hits="0"/>
+                        <line number="22" hits="1"/>
+                        <line number="24" hits="1"/>
+                        <line number="29" hits="1"/>
+                        <line number="31" hits="1"/>
+                    </lines>
                 </class>
             </classes>
         </package>

--- a/tests/_files/BankAccount-cobertura.xml
+++ b/tests/_files/BankAccount-cobertura.xml
@@ -1,55 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
 <coverage lines-valid="10" lines-covered="5" line-rate="0.5" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="%s" complexity="5" version="0.1">
-    <sources>
-        <source>%s</source>
-    </sources>
-    <packages>
-        <package name="BankAccount" line-rate="0.5" branch-rate="0">
-            <classes>
-                <class name="BankAccount" filename="%sBankAccount.php" line-rate="1" branch-rate="1">
-                    <methods>
-                        <method name="getBalance" hits="2" signature="()V">
-                            <lines>
-                                <line number="8" hits="2"/>
-                            </lines>
-                        </method>
-                        <method name="setBalance" hits="0" signature="()V">
-                            <lines>
-                                <line number="13" hits="0"/>
-                                <line number="14" hits="0"/>
-                                <line number="15" hits="0"/>
-                                <line number="16" hits="0"/>
-                                <line number="17" hits="0"/>
-                            </lines>
-                        </method>
-                        <method name="depositMoney" hits="3" signature="()V">
-                            <lines>
-                                <line number="22" hits="2"/>
-                                <line number="24" hits="1"/>
-                            </lines>
-                        </method>
-                        <method name="withdrawMoney" hits="3" signature="()V">
-                            <lines>
-                                <line number="29" hits="2"/>
-                                <line number="31" hits="1"/>
-                            </lines>
-                        </method>
-                    </methods>
-                    <lines>
-                        <line number="8" hits="2"/>
-                        <line number="13" hits="0"/>
-                        <line number="14" hits="0"/>
-                        <line number="15" hits="0"/>
-                        <line number="16" hits="0"/>
-                        <line number="17" hits="0"/>
-                        <line number="22" hits="2"/>
-                        <line number="24" hits="1"/>
-                        <line number="29" hits="2"/>
-                        <line number="31" hits="1"/>
-                    </lines>
-                </class>
-            </classes>
-        </package>
-    </packages>
+  <sources>
+    <source>%s/tests/_files</source>
+  </sources>
+  <packages>
+    <package name="BankAccount" line-rate="0.5" branch-rate="0" complexity="5">
+      <classes>
+        <class name="BankAccount" complexity="5" branch-rate="0" line-rate="0.5" filename="%sBankAccount.php">
+          <methods>
+            <method name="getBalance" signature="getBalance()" complexity="1" branch-rate="0" line-rate="1">
+              <lines>
+                <line number="8" hits="2"/>
+              </lines>
+            </method>
+            <method name="setBalance" signature="setBalance($balance)" complexity="2" branch-rate="0" line-rate="0">
+              <lines>
+                <line number="13" hits="0"/>
+                <line number="14" hits="0"/>
+                <line number="15" hits="0"/>
+                <line number="16" hits="0"/>
+              </lines>
+            </method>
+            <method name="depositMoney" signature="depositMoney($balance)" complexity="1" branch-rate="0" line-rate="1">
+              <lines>
+                <line number="22" hits="2"/>
+                <line number="24" hits="1"/>
+              </lines>
+            </method>
+            <method name="withdrawMoney" signature="withdrawMoney($balance)" complexity="1" branch-rate="0" line-rate="1">
+              <lines>
+                <line number="29" hits="2"/>
+                <line number="31" hits="1"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="8" hits="2"/>
+            <line number="13" hits="0"/>
+            <line number="14" hits="0"/>
+            <line number="15" hits="0"/>
+            <line number="16" hits="0"/>
+            <line number="22" hits="2"/>
+            <line number="24" hits="1"/>
+            <line number="29" hits="2"/>
+            <line number="31" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
 </coverage>

--- a/tests/_files/class-with-anonymous-function-cobertura.xml
+++ b/tests/_files/class-with-anonymous-function-cobertura.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="8" lines-covered="7" line-rate="0.875" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="%s" complexity="1" version="0.1">
+  <sources>
+    <source>%s/tests/_files</source>
+  </sources>
+  <packages>
+    <package name="anonymous" line-rate="0.875" branch-rate="0" complexity="1">
+      <classes>
+        <class name="CoveredClassWithAnonymousFunctionInStaticMethod" complexity="1" branch-rate="0" line-rate="0.875" filename="%ssource_with_class_and_anonymous_function.php">
+          <methods>
+            <method name="runAnonymous" signature="runAnonymous()" complexity="1" branch-rate="0" line-rate="0.875">
+              <lines>
+                <line number="7" hits="1"/>
+                <line number="9" hits="1"/>
+                <line number="10" hits="0"/>
+                <line number="12" hits="1"/>
+                <line number="13" hits="1"/>
+                <line number="14" hits="1"/>
+                <line number="17" hits="1"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="7" hits="1"/>
+            <line number="9" hits="1"/>
+            <line number="10" hits="0"/>
+            <line number="12" hits="1"/>
+            <line number="13" hits="1"/>
+            <line number="14" hits="1"/>
+            <line number="17" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/_files/ignored-lines-cobertura.xml
+++ b/tests/_files/ignored-lines-cobertura.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="0" lines-covered="0" line-rate="0" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="%s" complexity="2" version="0.1">
+  <sources>
+    <source>%s/tests/_files</source>
+  </sources>
+  <packages>
+    <package name="ignored" line-rate="0" branch-rate="0" complexity="2">
+      <classes>
+        <class name="Foo" complexity="1" branch-rate="0" line-rate="0" filename="%ssource_with_ignore.php">
+          <methods/>
+          <lines/>
+        </class>
+        <class name="Bar" complexity="1" branch-rate="0" line-rate="0" filename="%ssource_with_ignore.php">
+          <methods/>
+          <lines/>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/tests/CoberturaTest.php
+++ b/tests/tests/CoberturaTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Report;
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\TestCase;
+
+/**
+ * @covers \SebastianBergmann\CodeCoverage\Report\Cobertura
+ */
+class CoberturaTest extends TestCase
+{
+    public function testCloverForBankAccountTest(): void
+    {
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccount-cobertura.xml',
+            $cobertura->process($this->getCoverageForBankAccount(), 'BankAccount')
+        );
+    }
+
+    public function testCloverForFileWithIgnoredLines(): void
+    {
+        $this->markTestIncomplete();
+
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'ignored-lines-clover.xml',
+            $cobertura->process($this->getCoverageForFileWithIgnoredLines(), 'BankAccount')
+        );
+    }
+
+    public function testCloverForClassWithAnonymousFunction(): void
+    {
+        $this->markTestIncomplete();
+
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'class-with-anonymous-function-clover.xml',
+            $cobertura->process($this->getCoverageForClassWithAnonymousFunction(), 'BankAccount')
+        );
+    }
+}

--- a/tests/tests/CoberturaTest.php
+++ b/tests/tests/CoberturaTest.php
@@ -28,25 +28,21 @@ class CoberturaTest extends TestCase
 
     public function testCloverForFileWithIgnoredLines(): void
     {
-        $this->markTestIncomplete();
-
         $cobertura = new Cobertura;
 
         $this->assertStringMatchesFormatFile(
             TEST_FILES_PATH . 'ignored-lines-cobertura.xml',
-            $cobertura->process($this->getCoverageForFileWithIgnoredLines(), 'BankAccount')
+            $cobertura->process($this->getCoverageForFileWithIgnoredLines(), 'ignored')
         );
     }
 
     public function testCloverForClassWithAnonymousFunction(): void
     {
-        $this->markTestIncomplete();
-
         $cobertura = new Cobertura;
 
         $this->assertStringMatchesFormatFile(
             TEST_FILES_PATH . 'class-with-anonymous-function-cobertura.xml',
-            $cobertura->process($this->getCoverageForClassWithAnonymousFunction(), 'BankAccount')
+            $cobertura->process($this->getCoverageForClassWithAnonymousFunction(), 'anonymous')
         );
     }
 }

--- a/tests/tests/CoberturaTest.php
+++ b/tests/tests/CoberturaTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 /*
  * This file is part of phpunit/php-code-coverage.
  *
@@ -9,7 +9,6 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report;
 
-use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\TestCase;
 
 /**
@@ -34,7 +33,7 @@ class CoberturaTest extends TestCase
         $cobertura = new Cobertura;
 
         $this->assertStringMatchesFormatFile(
-            TEST_FILES_PATH . 'ignored-lines-clover.xml',
+            TEST_FILES_PATH . 'ignored-lines-cobertura.xml',
             $cobertura->process($this->getCoverageForFileWithIgnoredLines(), 'BankAccount')
         );
     }
@@ -46,7 +45,7 @@ class CoberturaTest extends TestCase
         $cobertura = new Cobertura;
 
         $this->assertStringMatchesFormatFile(
-            TEST_FILES_PATH . 'class-with-anonymous-function-clover.xml',
+            TEST_FILES_PATH . 'class-with-anonymous-function-cobertura.xml',
             $cobertura->process($this->getCoverageForClassWithAnonymousFunction(), 'BankAccount')
         );
     }


### PR DESCRIPTION
Attempting to add Cobertura support, addressing #6, in case this is something we want to have.

The report should be valid against <http://cobertura.sourceforge.net/xml/coverage-04.dtd>, and I need to know how to represent the `branch-rate` and related data. Is that something the coverage collector can provide? `line-rate` and related are simple enough.

The tests are work in progress as well, need to add the example files for the other types of coverage reports as well.

Other notes:

Cobertura, as originating in the Java world, has no concept of code outside classes. This means we probably can't display "raw" PHP file code coverage (e.g. stuff like `functions.php`, `index.php` and so on) in these reports unless we mangle the data to fit report structure in some way.