### PR TITLE
Include driver code in code coverage to enable proper self-test

### DIFF
--- a/src/Driver/PCOV.php
+++ b/src/Driver/PCOV.php
@@ -11,8 +11,6 @@ namespace SebastianBergmann\CodeCoverage\Driver;
 
 /**
  * Driver for PCOV code coverage functionality.
- *
- * @codeCoverageIgnore
  */
 final class PCOV implements Driver
 {

--- a/src/Driver/PHPDBG.php
+++ b/src/Driver/PHPDBG.php
@@ -13,8 +13,6 @@ use SebastianBergmann\CodeCoverage\RuntimeException;
 
 /**
  * Driver for PHPDBG's code coverage functionality.
- *
- * @codeCoverageIgnore
  */
 final class PHPDBG implements Driver
 {

--- a/src/Driver/Xdebug.php
+++ b/src/Driver/Xdebug.php
@@ -14,8 +14,6 @@ use SebastianBergmann\CodeCoverage\RuntimeException;
 
 /**
  * Driver for Xdebug's code coverage functionality.
- *
- * @codeCoverageIgnore
  */
 final class Xdebug implements Driver
 {


### PR DESCRIPTION
Hello @sebastianbergmann

Please see attached a PR to remove `@codeCoverageIgnore` declarations from the driver classes.

Rationale for the change is this:

- In the Xdebug driver, there is code to cleanup bad output from Xdebug (https://github.com/sebastianbergmann/php-code-coverage/blob/master/src/Driver/Xdebug.php#L76)  
- When Xdebug is configured to return branch coverage data (#380), the data that is returned is in a different format from that used by line coverage (see https://xdebug.org/docs/code_coverage)
- This code would therefore need to be adjusted as part of work on #380
- Except that Xdebug returning such bogus data seems like a really weird thing for it to do, and upon investigation I cannot make it do that in my tests
- `git blame` reveals the code has been in the code base since v2 (see https://github.com/sebastianbergmann/php-code-coverage/commit/577fdf3f53ddff207d579f1625fe1398dd2b7613 and https://github.com/sebastianbergmann/php-code-coverage/commit/121d8c7d8c79fd7c77287d2472d1a2dfca1efacf), which combined with the fact I cannot reproduce the behaviour strongly suggests to me that it was to workaround an issue in an ancient version of Xdebug that has long since been fixed
- as a final confirmation to prove the code is now obsolete before submitting a PR to remove it, I wanted to check the code coverage data from php-code-coverage's own test suite - if the code was not executed but the test suite was still passing then that would provide additional reassurance that it could be safely removed
- except that the drivers are excluded from code coverage so it is not possible to use the coverage report to do this

The drivers have been excluded for a very long time, the commit that originally introduced the exclusion for the whole Xdebug driver didn't include any rationale, it simply says "Simplify" (see https://github.com/sebastianbergmann/php-code-coverage/commit/9db2cc428a4cc6152414cfa2de707607d8c190a3). Since then, drivers for phpdbg and pcov have been added but I can't find any reason for the exclusions there other than cargo-culting/copy-pasting.

I can't think of a reason why they should not be included, are you able to remember that far back and why you might have initially excluded them? The phpdbg driver in particular does a lot of post-processing on the data before handing it off and it would be good to have that show up in reports as something that doesn't have tests.