### PR TITLE
Smarter filter use

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -897,7 +897,7 @@ final class CodeCoverage
         }
 
         if ($runtime->hasPCOV()) {
-            return new PCOV;
+            return new PCOV($filter);
         }
 
         if ($runtime->hasXdebug()) {

--- a/src/Driver/PCOV.php
+++ b/src/Driver/PCOV.php
@@ -9,11 +9,23 @@
  */
 namespace SebastianBergmann\CodeCoverage\Driver;
 
+use SebastianBergmann\CodeCoverage\Filter;
+
 /**
  * Driver for PCOV code coverage functionality.
  */
 final class PCOV implements Driver
 {
+    /**
+     * @var Filter
+     */
+    private $filter;
+
+    public function __construct(Filter $filter)
+    {
+        $this->filter = $filter;
+    }
+
     /**
      * Start collection of code coverage information.
      */
@@ -29,14 +41,9 @@ final class PCOV implements Driver
     {
         \pcov\stop();
 
-        $waiting = \pcov\waiting();
-        $collect = [];
+        $collect = \pcov\collect(\pcov\inclusive, $this->filter->getWhitelist());
 
-        if ($waiting) {
-            $collect = \pcov\collect(\pcov\inclusive, $waiting);
-
-            \pcov\clear();
-        }
+        \pcov\clear();
 
         return $collect;
     }

--- a/src/Driver/Xdebug.php
+++ b/src/Driver/Xdebug.php
@@ -30,7 +30,7 @@ final class Xdebug implements Driver
     /**
      * @throws RuntimeException
      */
-    public function __construct(Filter $filter = null)
+    public function __construct(Filter $filter)
     {
         if (!\extension_loaded('xdebug')) {
             throw new RuntimeException('This driver requires Xdebug');
@@ -40,11 +40,8 @@ final class Xdebug implements Driver
             throw new RuntimeException('xdebug.coverage_enable=On has to be set in php.ini');
         }
 
-        if ($filter === null) {
-            $filter = new Filter;
-        }
-
         $this->filter = $filter;
+        \xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_WHITELIST, $this->filter->getWhitelist());
     }
 
     /**

--- a/tests/tests/Driver/XdebugTest.php
+++ b/tests/tests/Driver/XdebugTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+use SebastianBergmann\Environment\Runtime;
+
+/**
+ * @covers SebastianBergmann\CodeCoverage\Driver\Xdebug
+ */
+class XdebugTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $runtime = new Runtime;
+
+        if (!$runtime->hasXdebug()) {
+            $this->markTestSkipped('This test is only applicable to Xdebug');
+        }
+
+        if (!xdebug_code_coverage_started()) {
+            $this->markTestSkipped('This test requires code coverage to be running');
+        }
+    }
+
+    public function testFilterWorks(): void
+    {
+        $bankAccount = TEST_FILES_PATH . 'BankAccount.php';
+
+        require $bankAccount;
+        $this->assertArrayNotHasKey($bankAccount, \xdebug_get_code_coverage());
+    }
+}


### PR DESCRIPTION
It is well-known that Xdebug requires a lot of resources in order to do it's work and running a test suite under Xdebug to generate code coverage data is therefore _a lot_ slower than running it without.

For this reason, PHPUnit has the ability for a user to generate an Xdebug filter script which can be used on subsequent executions to significantly speed up coverage by telling Xdebug to ignore code not in the whitelist e.g. in `vendor`. Since it requires manual setup work from them and is not "out of the box", most users do not do this.

Since the filter script must be executed **before** the other files are executed, it is not possible to have a fully automatic version of this. However it _is_ possible to get something fairly close, perhaps 95% as efficient by automatic means.

When the Xdebug driver class is constructed, it receives the whitelist filter configuration. By initiating the built in Xdebug filter at this time, _part_ of PHPUnit is already loaded, _part_ of php-code-coverage is already loaded and it's too late for Xdebug to be able to exclude them. However, the rest of PHPUnit, the rest of php-code-coverage, the other phpunit/* codebases (notably php-token-stream), the rest of `vendor` and the contents of `test` _can_ all be excluded i.e. actually most things.

This is essential for path coverage (#380) as the Xdebug memory requirements are otherwise very very large. It also allows most users (those not using a prepend script) to get a significant speed boost even when using standard line-based coverage.

Those who do use a prepend script can continue to do so to obtain absolute maximum performance, since the whitelist of their filter script and the whitelist set here at runtime will the same list this will not undo anything for them.

A similar, but much smaller gain can also be had for PCOV - the PCOV driver currently outputs coverage data for _all_ files which are then filtered later by php-code-coverage. Since we have the list of files we're interested in, we can have the output filtering done inside the PCOV extension itself.