### PR TITLE
Encapsulate raw coverage data from drivers

### DIFF
--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -9,6 +9,8 @@
  */
 namespace SebastianBergmann\CodeCoverage\Driver;
 
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
+
 /**
  * Interface for code coverage drivers.
  */
@@ -43,5 +45,5 @@ interface Driver
     /**
      * Stop collection of code coverage information.
      */
-    public function stop(): array;
+    public function stop(): RawCodeCoverageData;
 }

--- a/src/Driver/PCOV.php
+++ b/src/Driver/PCOV.php
@@ -10,6 +10,7 @@
 namespace SebastianBergmann\CodeCoverage\Driver;
 
 use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
 
 /**
  * Driver for PCOV code coverage functionality.
@@ -37,7 +38,7 @@ final class PCOV implements Driver
     /**
      * Stop collection of code coverage information.
      */
-    public function stop(): array
+    public function stop(): RawCodeCoverageData
     {
         \pcov\stop();
 
@@ -45,6 +46,6 @@ final class PCOV implements Driver
 
         \pcov\clear();
 
-        return $collect;
+        return new RawCodeCoverageData($collect);
     }
 }

--- a/src/Driver/PHPDBG.php
+++ b/src/Driver/PHPDBG.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage\Driver;
 
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
 use SebastianBergmann\CodeCoverage\RuntimeException;
 
 /**
@@ -45,7 +46,7 @@ final class PHPDBG implements Driver
     /**
      * Stop collection of code coverage information.
      */
-    public function stop(): array
+    public function stop(): RawCodeCoverageData
     {
         static $fetchedLines = [];
 
@@ -71,7 +72,7 @@ final class PHPDBG implements Driver
 
         $fetchedLines = \array_merge($fetchedLines, $sourceLines);
 
-        return $this->detectExecutedLines($fetchedLines, $dbgData);
+        return new RawCodeCoverageData($this->detectExecutedLines($fetchedLines, $dbgData));
     }
 
     /**

--- a/src/Driver/Xdebug.php
+++ b/src/Driver/Xdebug.php
@@ -10,6 +10,7 @@
 namespace SebastianBergmann\CodeCoverage\Driver;
 
 use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
 use SebastianBergmann\CodeCoverage\RuntimeException;
 
 /**
@@ -48,12 +49,12 @@ final class Xdebug implements Driver
     /**
      * Stop collection of code coverage information.
      */
-    public function stop(): array
+    public function stop(): RawCodeCoverageData
     {
         $data = \xdebug_get_code_coverage();
 
         \xdebug_stop_code_coverage();
 
-        return $data;
+        return new RawCodeCoverageData($data);
     }
 }

--- a/src/Exception/UnknownCoverageDataFormatException.php
+++ b/src/Exception/UnknownCoverageDataFormatException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+/**
+ * Exception that is raised when a driver supplies coverage data in a format that cannot be handled.
+ */
+final class UnknownCoverageDataFormatException extends RuntimeException
+{
+    public static function create(string $filename): self
+    {
+        return new self(
+            \sprintf(
+                'Coverage data for file "%s" must be in Xdebug-compatible format, see https://xdebug.org/docs/code_coverage',
+                $filename
+            )
+        );
+    }
+}

--- a/src/RawCodeCoverageData.php
+++ b/src/RawCodeCoverageData.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+/**
+ * Raw context-less code coverage data for SUT.
+ */
+final class RawCodeCoverageData
+{
+    /**
+     * Line coverage data.
+     *
+     * @see https://xdebug.org/docs/code_coverage for format
+     *
+     * @var array
+     */
+    private $lineData = [];
+
+    public function __construct(array $rawCoverage = [])
+    {
+        foreach ($rawCoverage as $file => $fileCoverageData) {
+            $hasOnlyIntegerKeys = \count(\array_filter(\array_keys($fileCoverageData), 'is_int')) === \count($fileCoverageData);
+
+            if ($hasOnlyIntegerKeys) {
+                $this->lineData[$file] = $fileCoverageData;
+            } elseif (\count($fileCoverageData) === 2 && isset($fileCoverageData['lines'], $fileCoverageData['functions'])) {
+                $this->lineData[$file] = $fileCoverageData['lines'];
+            } else {
+                throw UnknownCoverageDataFormatException::create($file);
+            }
+        }
+    }
+
+    public function clear(): void
+    {
+        $this->lineData = [];
+    }
+
+    public function getLineData(): array
+    {
+        return $this->lineData;
+    }
+
+    public function removeCoverageDataForFile(string $filename): void
+    {
+        unset($this->lineData[$filename]);
+    }
+
+    /**
+     * @param int[] $lines
+     */
+    public function keepCoverageDataOnlyForLines(string $filename, array $lines): void
+    {
+        $this->lineData[$filename] = \array_intersect_key($this->lineData[$filename], \array_flip($lines));
+    }
+
+    /**
+     * @param int[] $lines
+     */
+    public function removeCoverageDataForLines(string $filename, array $lines): void
+    {
+        $this->lineData[$filename] = \array_diff_key($this->lineData[$filename], \array_flip($lines));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected function getXdebugDataForBankAccount()
     {
         return [
-            [
+            new RawCodeCoverageData([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
                     9  => -2,
@@ -39,24 +39,24 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                     31 => -1,
                     32 => -2,
                 ],
-            ],
-            [
+            ]),
+            new RawCodeCoverageData([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
                     13 => 1,
                     16 => 1,
                     29 => 1,
                 ],
-            ],
-            [
+            ]),
+            new RawCodeCoverageData([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
                     13 => 1,
                     16 => 1,
                     22 => 1,
                 ],
-            ],
-            [
+            ]),
+            new RawCodeCoverageData([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
                     13 => 1,
@@ -68,7 +68,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                     29 => 1,
                     31 => 1,
                 ],
-            ],
+            ]),
         ];
     }
 
@@ -314,14 +314,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $stub->expects($this->any())
             ->method('stop')
             ->will($this->returnValue(
-                [
-                    TEST_FILES_PATH . 'source_with_ignore.php' => [
-                        2 => 1,
-                        4 => -1,
-                        6 => -1,
-                        7 => 1,
-                    ],
-                ]
+                new RawCodeCoverageData(
+                    [
+                        TEST_FILES_PATH . 'source_with_ignore.php' => [
+                            2 => 1,
+                            4 => -1,
+                            6 => -1,
+                            7 => 1,
+                        ],
+                    ]
+                )
             ));
 
         return $stub;
@@ -350,19 +352,21 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $stub->expects($this->any())
             ->method('stop')
             ->will($this->returnValue(
-                [
-                    TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php' => [
-                        7  => 1,
-                        9  => 1,
-                        10 => -1,
-                        11 => 1,
-                        12 => 1,
-                        13 => 1,
-                        14 => 1,
-                        17 => 1,
-                        18 => 1,
-                    ],
-                ]
+                new RawCodeCoverageData(
+                    [
+                        TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php' => [
+                            7  => 1,
+                            9  => 1,
+                            10 => -1,
+                            11 => 1,
+                            12 => 1,
+                            13 => 1,
+                            14 => 1,
+                            17 => 1,
+                            18 => 1,
+                        ],
+                    ]
+                )
             ));
 
         return $stub;
@@ -386,7 +390,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         $stub->expects($this->any())
             ->method('stop')
-            ->will($this->returnValue([]));
+            ->will($this->returnValue(new RawCodeCoverageData([])));
 
         return $stub;
     }

--- a/tests/tests/CodeCoverageTest.php
+++ b/tests/tests/CodeCoverageTest.php
@@ -44,7 +44,7 @@ class CodeCoverageTest extends TestCase
     {
         $this->expectException(Exception::class);
 
-        $this->coverage->append([], null);
+        $this->coverage->append(new RawCodeCoverageData([]), null);
     }
 
     public function testCollect(): void
@@ -290,12 +290,12 @@ class CodeCoverageTest extends TestCase
         $this->coverage->filter()->addDirectoryToWhitelist(TEST_FILES_PATH);
         $this->coverage->setCheckForUnexecutedCoveredCode(true);
 
-        $data = [
+        $data = new RawCodeCoverageData([
             TEST_FILES_PATH . 'BankAccount.php' => [
                 29 => -1,
                 31 => -1,
             ],
-        ];
+        ]);
 
         $linesToBeCovered = [
             TEST_FILES_PATH . 'BankAccount.php' => [
@@ -316,12 +316,12 @@ class CodeCoverageTest extends TestCase
         $this->coverage->filter()->addDirectoryToWhitelist(TEST_FILES_PATH);
         $this->coverage->setCheckForUnexecutedCoveredCode(true);
 
-        $data = [
+        $data = new RawCodeCoverageData([
             TEST_FILES_PATH . 'BankAccount.php' => [
                 29 => -1,
                 31 => -1,
             ],
-        ];
+        ]);
 
         $linesToBeCovered = [
             TEST_FILES_PATH . 'BankAccount.php' => [

--- a/tests/tests/RawCodeCoverageDataTest.php
+++ b/tests/tests/RawCodeCoverageDataTest.php
@@ -1,0 +1,218 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage;
+
+class RawCodeCoverageDataTest extends TestCase
+{
+    /**
+     * In the standard XDebug format, there is only line data. Therefore output should match input.
+     */
+    public function testLineDataFromStandardXDebugFormat(): void
+    {
+        $lineDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($lineDataFromDriver);
+        $this->assertEquals($lineDataFromDriver, $dataObject->getLineData());
+    }
+
+    /**
+     * In the branch-check XDebug format, the line data exists inside a "lines" array key.
+     */
+    public function testLineDataFromBranchCheckXDebugFormat(): void
+    {
+        $rawDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                'lines' => [
+                    8  => 1,
+                    9  => -2,
+                    13 => -1,
+                ],
+                'functions' => [
+
+                ],
+            ],
+        ];
+
+        $lineData = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($rawDataFromDriver);
+        $this->assertEquals($lineData, $dataObject->getLineData());
+    }
+
+    /**
+     * Coverage data that does not match a known format should throw an exception.
+     */
+    public function testDataFromUnknownFormat(): void
+    {
+        $this->expectException(UnknownCoverageDataFormatException::class);
+
+        $lineDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                'executedLines' => [
+                    8,
+                ],
+                'unExecutedLines' => [
+                    13,
+                ],
+                'nonExecutableLines' => [
+                    9,
+                ],
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($lineDataFromDriver);
+    }
+
+    public function testClear(): void
+    {
+        $lineDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($lineDataFromDriver);
+        $dataObject->clear();
+        $this->assertEmpty($dataObject->getLineData());
+    }
+
+    public function testRemoveCoverageDataForFile(): void
+    {
+        $lineDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+            '/some/path/SomeOtherClass.php' => [
+                18  => 1,
+                19  => -2,
+                113 => -1,
+            ],
+            '/some/path/AnotherClass.php' => [
+                28  => 1,
+                29  => -2,
+                213 => -1,
+            ],
+        ];
+
+        $expectedFilterResult = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+            '/some/path/AnotherClass.php' => [
+                28  => 1,
+                29  => -2,
+                213 => -1,
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($lineDataFromDriver);
+        $dataObject->removeCoverageDataForFile('/some/path/SomeOtherClass.php');
+        $this->assertEquals($expectedFilterResult, $dataObject->getLineData());
+    }
+
+    public function testKeepCoverageDataOnlyForLines(): void
+    {
+        $lineDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+            '/some/path/SomeOtherClass.php' => [
+                18  => 1,
+                19  => -2,
+                113 => -1,
+            ],
+            '/some/path/AnotherClass.php' => [
+                28  => 1,
+                29  => -2,
+                213 => -1,
+            ],
+        ];
+
+        $expectedFilterResult = [
+            '/some/path/SomeClass.php' => [
+                9  => -2,
+                13 => -1,
+            ],
+            '/some/path/SomeOtherClass.php' => [
+            ],
+            '/some/path/AnotherClass.php' => [
+                28  => 1,
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($lineDataFromDriver);
+        $dataObject->keepCoverageDataOnlyForLines('/some/path/SomeClass.php', [9, 13]);
+        $dataObject->keepCoverageDataOnlyForLines('/some/path/SomeOtherClass.php', [999]);
+        $dataObject->keepCoverageDataOnlyForLines('/some/path/AnotherClass.php', [28]);
+        $this->assertEquals($expectedFilterResult, $dataObject->getLineData());
+    }
+
+    public function testRemoveCoverageDataForLines(): void
+    {
+        $lineDataFromDriver = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+                9  => -2,
+                13 => -1,
+            ],
+            '/some/path/SomeOtherClass.php' => [
+                18  => 1,
+                19  => -2,
+                113 => -1,
+            ],
+            '/some/path/AnotherClass.php' => [
+                28  => 1,
+                29  => -2,
+                213 => -1,
+            ],
+        ];
+
+        $expectedFilterResult = [
+            '/some/path/SomeClass.php' => [
+                8  => 1,
+            ],
+            '/some/path/SomeOtherClass.php' => [
+                18  => 1,
+                19  => -2,
+                113 => -1,
+            ],
+            '/some/path/AnotherClass.php' => [
+                29  => -2,
+                213 => -1,
+            ],
+        ];
+
+        $dataObject = new RawCodeCoverageData($lineDataFromDriver);
+        $dataObject->removeCoverageDataForLines('/some/path/SomeClass.php', [9, 13]);
+        $dataObject->removeCoverageDataForLines('/some/path/SomeOtherClass.php', [999]);
+        $dataObject->removeCoverageDataForLines('/some/path/AnotherClass.php', [28]);
+        $this->assertEquals($expectedFilterResult, $dataObject->getLineData());
+    }
+}


### PR DESCRIPTION
Hi @sebastianbergmann 

Please find attached a PR for the first piece of the enabling work for #380. The goal of this particular PR is not to add new functionality, merely to lay groundwork.

What does this PR do?
- It replaces the return type of `array` from `Driver->stop()` with a new object `RawCodeCoverageData`, with consequential adjustments to the rest of the code
- It replaces the direct data manipulation that was previously inside `CodeCoverage` with usage of named methods on `RawCodeCoverageData`
- In the Xdebug driver, it adds the ability to accept and propagate driver data in either the traditional line only format, or the extended branch data format

Please note this PR does not adjust the internal `$this->data` array used by the `CodeCoverage` class. I do plan on encapsulating that too, but it will be in a different PR.
