### PR TITLE
Improve consistency in handling of namespaces

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -518,6 +518,10 @@ final class File extends AbstractNode
         $link   = $this->getId() . '.html#';
 
         foreach ($traits as $traitName => $trait) {
+            if (!empty($trait['package']['namespace'])) {
+                $traitName = $trait['package']['namespace'] . '\\' . $traitName;
+            }
+
             $this->traits[$traitName] = [
                 'traitName'       => $traitName,
                 'methods'         => [],

--- a/src/Report/Text.php
+++ b/src/Report/Text.php
@@ -200,16 +200,14 @@ final class Text
                     }
                 }
 
-                $namespace = '';
+                $package = '';
 
-                if (!empty($class['package']['namespace'])) {
-                    $namespace = '\\' . $class['package']['namespace'] . '::';
-                } elseif (!empty($class['package']['fullPackage'])) {
-                    $namespace = '@' . $class['package']['fullPackage'] . '::';
+                if (!empty($class['package']['fullPackage'])) {
+                    $package = '@' . $class['package']['fullPackage'] . '::';
                 }
 
-                $classCoverage[$namespace . $className] = [
-                    'namespace'         => $namespace,
+                $classCoverage[$package . $className] = [
+                    'namespace'         => $class['package']['namespace'],
                     'className '        => $className,
                     'methodsCovered'    => $coveredMethods,
                     'methodCount'       => $classMethods,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -138,6 +138,124 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return $coverage;
     }
 
+    protected function getXdebugDataForNamespacedBankAccount()
+    {
+        return [
+            RawCodeCoverageData::fromXdebugWithoutPathCoverage([
+                TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
+                    14  => 1,
+                    15  => -2,
+                    19  => -1,
+                    20  => -1,
+                    21  => -1,
+                    22  => -1,
+                    24  => -1,
+                    28  => -1,
+                    30  => -1,
+                    31  => -2,
+                    35  => -1,
+                    37  => -1,
+                    38  => -2,
+                ],
+            ]),
+            RawCodeCoverageData::fromXdebugWithoutPathCoverage([
+                TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
+                    14  => 1,
+                    19  => 1,
+                    22  => 1,
+                    35  => 1,
+                ],
+            ]),
+            RawCodeCoverageData::fromXdebugWithoutPathCoverage([
+                TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
+                    14  => 1,
+                    19  => 1,
+                    22  => 1,
+                    28  => 1,
+                ],
+            ]),
+            RawCodeCoverageData::fromXdebugWithoutPathCoverage([
+                TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
+                    14  => 1,
+                    19  => 1,
+                    20  => 1,
+                    21  => 1,
+                    24  => 1,
+                    28  => 1,
+                    30  => 1,
+                    35  => 1,
+                    37  => 1,
+                ],
+            ]),
+        ];
+    }
+
+    protected function getCoverageForNamespacedBankAccount(): CodeCoverage
+    {
+        $data = $this->getXdebugDataForNamespacedBankAccount();
+
+        $stub = $this->createMock(Driver::class);
+
+        $stub->expects($this->any())
+            ->method('stop')
+            ->will($this->onConsecutiveCalls(
+                $data[0],
+                $data[1],
+                $data[2],
+                $data[3]
+            ));
+
+        $filter = new Filter;
+        $filter->addFileToWhitelist(TEST_FILES_PATH . 'NamespacedBankAccount.php');
+
+        $coverage = new CodeCoverage($stub, $filter);
+
+        $coverage->start(
+            new \BankAccountTest('testBalanceIsInitiallyZero'),
+            true
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => \range(12, 15)]
+        );
+
+        $coverage->start(
+            new \BankAccountTest('testBalanceCannotBecomeNegative')
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => \range(33, 38)]
+        );
+
+        $coverage->start(
+            new \BankAccountTest('testBalanceCannotBecomeNegative2')
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => \range(26, 31)]
+        );
+
+        $coverage->start(
+            new \BankAccountTest('testDepositWithdrawMoney')
+        );
+
+        $coverage->stop(
+            true,
+            [
+                TEST_FILES_PATH . 'NamespacedBankAccount.php' => \array_merge(
+                    \range(12, 15),
+                    \range(26, 31),
+                    \range(33, 38)
+                ),
+            ]
+        );
+
+        return $coverage;
+    }
+
     protected function getCoverageForBankAccountForFirstTwoTests(): CodeCoverage
     {
         $data = $this->getXdebugDataForBankAccount();

--- a/tests/_files/BankAccount-text-summary.txt
+++ b/tests/_files/BankAccount-text-summary.txt
@@ -1,0 +1,7 @@
+
+
+Code Coverage Report Summary:
+  Classes:  0.00% (0/1)      
+  Methods: 75.00% (3/4)      
+  Lines:   50.00% (5/10)     
+

--- a/tests/_files/NamespacedBankAccount-text.txt
+++ b/tests/_files/NamespacedBankAccount-text.txt
@@ -1,0 +1,14 @@
+
+
+Code Coverage Report:   
+  %s
+                        
+ Summary:               
+  Classes:  0.00% (0/1) 
+  Methods: 75.00% (3/4) 
+  Lines:   50.00% (5/10)
+
+@OldStylePackageName::SomeNamespace\BankAccount
+  Methods:  ( 0/ 0)   Lines:  (  0/  0)
+SomeNamespace\BankAccountTrait
+  Methods:  75.00% ( 3/ 4)   Lines:  50.00% (  5/ 10)

--- a/tests/_files/NamespacedBankAccount.php
+++ b/tests/_files/NamespacedBankAccount.php
@@ -1,0 +1,39 @@
+<?php
+namespace SomeNamespace;
+/** @package OldStylePackageName */
+class BankAccount
+{
+    use BankAccountTrait;
+}
+
+trait BankAccountTrait {
+    protected $balance = 0;
+
+    public function getBalance()
+    {
+        return $this->balance;
+    }
+
+    protected function setBalance($balance)
+    {
+        if ($balance >= 0) {
+            $this->balance = $balance;
+        } else {
+            throw new \RuntimeException;
+        }
+    }
+
+    public function depositMoney($balance)
+    {
+        $this->setBalance($this->getBalance() + $balance);
+
+        return $this->getBalance();
+    }
+
+    public function withdrawMoney($balance)
+    {
+        $this->setBalance($this->getBalance() - $balance);
+
+        return $this->getBalance();
+    }
+}

--- a/tests/tests/FilterTest.php
+++ b/tests/tests/FilterTest.php
@@ -64,6 +64,7 @@ class FilterTest extends TestCase
             TEST_FILES_PATH . 'NamespaceCoverageProtectedTest.php',
             TEST_FILES_PATH . 'NamespaceCoveragePublicTest.php',
             TEST_FILES_PATH . 'NamespaceCoveredClass.php',
+            TEST_FILES_PATH . 'NamespacedBankAccount.php',
             TEST_FILES_PATH . 'NotExistingCoveredElementTest.php',
             TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php',
             TEST_FILES_PATH . 'source_with_ignore.php',

--- a/tests/tests/TextTest.php
+++ b/tests/tests/TextTest.php
@@ -26,6 +26,26 @@ class TextTest extends TestCase
         );
     }
 
+    public function testTextOnlySummaryForBankAccountTest(): void
+    {
+        $text = new Text(50, 90, false, true);
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccount-text-summary.txt',
+            \str_replace(\PHP_EOL, "\n", $text->process($this->getCoverageForBankAccount()))
+        );
+    }
+
+    public function testTextForNamespacedBankAccountTest(): void
+    {
+        $text = new Text(50, 90, true, false);
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'NamespacedBankAccount-text.txt',
+            \str_replace(\PHP_EOL, "\n", $text->process($this->getCoverageForNamespacedBankAccount()))
+        );
+    }
+
     public function testTextForFileWithIgnoredLines(): void
     {
         $text = new Text(50, 90, false, false);


### PR DESCRIPTION
Hello @sebastianbergmann 

In #455, the internal classname used as an array key by the report was adjusted from using the simple classname to the FQCN. However although traits use the same basic data structure, the same adjustment was not done for them. This PR fixes that so the correct data can be stored and looked up.

Namespaced functions seem to be OK as the namespace is already included in the result of `->getName()`.

The fix from #455 also seems to have a side-effect on the text report, since this had seperate code to include the namespace in the output. With the classname now being the FQCN, the text report has been doubling up output for the last couple of years. This PR therefore also adjusts the text report to eliminate that.


Before
![image](https://user-images.githubusercontent.com/1571110/82236281-ca021900-992b-11ea-8c50-1347de149d57.png)

After
![image](https://user-images.githubusercontent.com/1571110/82236325-d9816200-992b-11ea-8c62-f2f8b597642c.png)

