### PR TITLE
Correct missing highlighting of dead code

### DIFF
--- a/src/Report/Html/Renderer/Template/css/style.css
+++ b/src/Report/Html/Renderer/Template/css/style.css
@@ -48,7 +48,7 @@ body {
  background-color: #f2dede;
 }
 
-.table tbody td.warning, li.warning, span.warning {
+.table tbody tr.warning, .table tbody td.warning, li.warning, span.warning {
  background-color: #fcf8e3;
 }
 


### PR DESCRIPTION
Hello @sebastianbergmann 

I've noticed that dead code detection does not seem to be working correctly in the HTML report: the legend indicates that it should be highlighted in yellow but it currently outputs in white.

The HTML itself is correct, just needs a small tweak to the CSS.

Before
![image](https://user-images.githubusercontent.com/1571110/82254753-5b34b800-994b-11ea-9100-c90b74b98fc4.png)

After
![image](https://user-images.githubusercontent.com/1571110/82254788-6e478800-994b-11ea-9768-74be5d5c6cd1.png)
