### PR TITLE
Store captured branch/path function data

### DIFF
--- a/src/RawCodeCoverageData.php
+++ b/src/RawCodeCoverageData.php
@@ -21,30 +21,43 @@ final class RawCodeCoverageData
      */
     private $lineCoverage = [];
 
+    /**
+     * @var array
+     *
+     * @see https://xdebug.org/docs/code_coverage for format
+     */
+    private $functionCoverage = [];
+
     public static function fromXdebugWithoutPathCoverage(array $rawCoverage): self
     {
-        return new self($rawCoverage);
+        return new self($rawCoverage, []);
     }
 
     public static function fromXdebugWithPathCoverage(array $rawCoverage): self
     {
-        $lineCoverage = [];
+        $lineCoverage = $functionCoverage = [];
 
         foreach ($rawCoverage as $file => $fileCoverageData) {
-            $lineCoverage[$file] = $fileCoverageData['lines'];
+            if (isset($fileCoverageData['functions'])) {
+                $lineCoverage[$file]     = $fileCoverageData['lines'];
+                $functionCoverage[$file] = $fileCoverageData['functions'];
+            } else { // not every file has functions, Xdebug outputs just line data for these
+                $lineCoverage[$file] = $fileCoverageData;
+            }
         }
 
-        return new self($lineCoverage);
+        return new self($lineCoverage, $functionCoverage);
     }
 
-    private function __construct(array $lineCoverage)
+    private function __construct(array $lineCoverage, array $functionCoverage)
     {
-        $this->lineCoverage = $lineCoverage;
+        $this->lineCoverage     = $lineCoverage;
+        $this->functionCoverage = $functionCoverage;
     }
 
     public function clear(): void
     {
-        $this->lineCoverage = [];
+        $this->lineCoverage = $this->functionCoverage = [];
     }
 
     public function getLineCoverage(): array
@@ -54,7 +67,7 @@ final class RawCodeCoverageData
 
     public function removeCoverageDataForFile(string $filename): void
     {
-        unset($this->lineCoverage[$filename]);
+        unset($this->lineCoverage[$filename], $this->functionCoverage[$filename]);
     }
 
     /**

--- a/tests/tests/RawCodeCoverageDataTest.php
+++ b/tests/tests/RawCodeCoverageDataTest.php
@@ -30,7 +30,8 @@ final class RawCodeCoverageDataTest extends TestCase
     }
 
     /**
-     * In the path-coverage XDebug format, the line data exists inside a "lines" array key.
+     * In the path-coverage XDebug format, the line data exists inside a "lines" array key where the file has
+     * classes or functions. For files without them, the data is stored in the line-only format.
      */
     public function testLineDataFromPathCoverageXDebugFormat(): void
     {
@@ -45,6 +46,11 @@ final class RawCodeCoverageDataTest extends TestCase
 
                 ],
             ],
+            '/some/path/justAScript.php' => [
+                18  => 1,
+                19  => -2,
+                113 => -1,
+            ],
         ];
 
         $lineData = [
@@ -52,6 +58,11 @@ final class RawCodeCoverageDataTest extends TestCase
                 8  => 1,
                 9  => -2,
                 13 => -1,
+            ],
+            '/some/path/justAScript.php' => [
+                18  => 1,
+                19  => -2,
+                113 => -1,
             ],
         ];
 


### PR DESCRIPTION
Hi @sebastianbergmann 

This is the next piece for #380, just storing the data from Xdebug inside `RawCodeCoverageData`. Unfortunately I've had to add back a version of the format "guessing" that you asked to be removed before, as it turns out from my testing that where a covered file doesn't have any functions (e.g. a bootstrap or configuration file), then Xdebug outputs the line data in the flat format, rather than embedded inside a `lines` key. Sniffing on a per-file basis is therefore required.