### PR TITLE
Tidy up how uncovered files are handled

### DIFF
--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -222,10 +222,6 @@ final class Facade
         $testsObject = $this->project->getTests();
 
         foreach ($tests as $test => $result) {
-            if ($test === 'UNCOVERED_FILES_FROM_WHITELIST') {
-                continue;
-            }
-
             $testsObject->addTest($test, $result);
         }
     }


### PR DESCRIPTION
During the initial pass of whitelisted files in `initializeData()`, a processing step is undertaken on the collected coverage data to mark any executed code as non-executed since `UNCOVERED_FILES_FROM_WHITELIST` is not a real testcase id.

This can be simplified by simply not recording `UNCOVERED_FILES_FROM_WHITELIST` as a testcase id at all.

Doing this also means that the fake `UNCOVERED_FILES_FROM_WHITELIST` id can be kept internal to the `CodeCoverage` class and this implementation detail does not leak to the outside.