### PR TITLE
Don't crash when file structure changes

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -291,7 +291,7 @@ final class CodeCoverage
         $this->applyWhitelistFilter($rawData);
         $this->applyIgnoredLinesFilter($rawData);
 
-        $this->data->initializeFilesThatAreSeenTheFirstTime($rawData);
+        $this->data->initializeUnseenData($rawData);
 
         if (!$append) {
             return;

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -483,6 +483,10 @@ final class CodeCoverage
 
     private function applyWhitelistFilter(RawCodeCoverageData $data): void
     {
+        if (!$this->filter->hasWhitelist()) {
+            return;
+        }
+
         foreach (\array_keys($data->lineCoverage()) as $filename) {
             if ($this->filter->isFiltered($filename)) {
                 $data->removeCoverageDataForFile($filename);

--- a/src/Driver/XdebugDriver.php
+++ b/src/Driver/XdebugDriver.php
@@ -31,7 +31,9 @@ final class XdebugDriver extends Driver
             throw new RuntimeException('xdebug.coverage_enable=On has to be set in php.ini');
         }
 
-        \xdebug_set_filter(\XDEBUG_FILTER_CODE_COVERAGE, \XDEBUG_PATH_WHITELIST, $filter->getWhitelist());
+        if ($filter->hasWhitelist()) {
+            \xdebug_set_filter(\XDEBUG_FILTER_CODE_COVERAGE, \XDEBUG_PATH_WHITELIST, $filter->getWhitelist());
+        }
 
         $this->enableDeadCodeDetection();
     }

--- a/src/RawCodeCoverageData.php
+++ b/src/RawCodeCoverageData.php
@@ -205,6 +205,10 @@ final class RawCodeCoverageData
      */
     public function keepCoverageDataOnlyForLines(string $filename, array $lines): void
     {
+        if (!isset($this->lineCoverage[$filename])) {
+            return;
+        }
+
         $this->lineCoverage[$filename] = \array_intersect_key(
             $this->lineCoverage[$filename],
             \array_flip($lines)
@@ -233,6 +237,10 @@ final class RawCodeCoverageData
     public function removeCoverageDataForLines(string $filename, array $lines): void
     {
         if (empty($lines)) {
+            return;
+        }
+
+        if (!isset($this->lineCoverage[$filename])) {
             return;
         }
 

--- a/tests/tests/ProcessedCodeCoverageDataTest.php
+++ b/tests/tests/ProcessedCodeCoverageDataTest.php
@@ -66,4 +66,113 @@ final class ProcessedCodeCoverageDataTest extends TestCase
 
         $this->assertArrayHasKey(12, $existingCoverage->lineCoverage()['/some/path/SomeClass.php']);
     }
+
+    public function testMergeDoesNotCrashWhenFileContentsHaveChanged(): void
+    {
+        $coverage = new ProcessedCodeCoverageData;
+        $coverage->setFunctionCoverage(
+            [
+                '/some/path/SomeClass.php' => [
+                    'SomeClass->firstFunction' => [
+                        'branches' => [
+                            0 => [
+                                'op_start'   => 0,
+                                'op_end'     => 14,
+                                'line_start' => 20,
+                                'line_end'   => 25,
+                                'hit'        => [],
+                                'out'        => [
+                                ],
+                                'out_hit' => [
+                                ],
+                            ],
+                        ],
+                        'paths' => [
+                            0 => [
+                                'path' => [
+                                    0 => 0,
+                                ],
+                                'hit' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $newCoverage = new ProcessedCodeCoverageData;
+        $newCoverage->setFunctionCoverage(
+            [
+                '/some/path/SomeClass.php' => [
+                    'SomeClass->firstFunction' => [
+                        'branches' => [
+                            0 => [
+                                'op_start'   => 0,
+                                'op_end'     => 14,
+                                'line_start' => 20,
+                                'line_end'   => 25,
+                                'hit'        => [],
+                                'out'        => [
+                                ],
+                                'out_hit' => [
+                                ],
+                            ],
+                            1 => [
+                                'op_start'   => 15,
+                                'op_end'     => 16,
+                                'line_start' => 26,
+                                'line_end'   => 27,
+                                'hit'        => [],
+                                'out'        => [
+                                ],
+                                'out_hit' => [
+                                ],
+                            ],
+                        ],
+                        'paths' => [
+                            0 => [
+                                'path' => [
+                                    0 => 0,
+                                ],
+                                'hit' => [],
+                            ],
+                            1 => [
+                                'path' => [
+                                    0 => 1,
+                                ],
+                                'hit' => [],
+                            ],
+                        ],
+                    ],
+                    'SomeClass->secondFunction' => [
+                        'branches' => [
+                            0 => [
+                                'op_start'   => 0,
+                                'op_end'     => 24,
+                                'line_start' => 30,
+                                'line_end'   => 35,
+                                'hit'        => [],
+                                'out'        => [
+                                ],
+                                'out_hit' => [
+                                ],
+                            ],
+                        ],
+                        'paths' => [
+                            0 => [
+                                'path' => [
+                                    0 => 0,
+                                ],
+                                'hit' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $coverage->merge($newCoverage);
+
+        $this->assertArrayHasKey('SomeClass->secondFunction', $newCoverage->functionCoverage()['/some/path/SomeClass.php']);
+    }
 }


### PR DESCRIPTION
Hello @sebastianbergmann 

Having done some extended testing with path coverage against some additional codebases, I've encountered a few crash situations due to the current assumption that a file's structure once seen is consistent. In (at least) the following situations it is not.

* When using mocks, each new mock is created by `eval()`. This leads to new functions being associated with that file at runtime.
* When using traits, the coverage data includes the details of each class that uses the trait, however this data is only populated at runtime.
* When tests are run in seperate processes that involve dynamically created code, the branch and path details from each process do not always align e.g. Symfony's test suite appears to create different containers on disk using the same filename.

The attached PR avoid these issues by recursing deeper into the data and doing a more intelligent merge.