### PR TITLE
Bugfixes for PHPUnit integration

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -497,6 +497,10 @@ final class CodeCoverage
     private function applyIgnoredLinesFilter(RawCodeCoverageData $data): void
     {
         foreach (\array_keys($data->lineCoverage()) as $filename) {
+            if (!$this->filter->isFile($filename)) {
+                continue;
+            }
+
             $data->removeCoverageDataForLines($filename, $this->getLinesToBeIgnored($filename));
         }
     }

--- a/src/Driver/PcovDriver.php
+++ b/src/Driver/PcovDriver.php
@@ -36,7 +36,7 @@ final class PcovDriver extends Driver
     {
         \pcov\stop();
 
-        $collect = \pcov\collect(\pcov\inclusive, $this->filter->getWhitelist());
+        $collect = \pcov\collect(\pcov\inclusive, $this->filter->hasWhitelist() ? $this->filter->getWhitelist() : \pcov\waiting());
 
         \pcov\clear();
 


### PR DESCRIPTION
* Check if the filter is not empty before using it for PCOV
* Only apply ignored line filter to actual files, not eval()'d code

Fixes https://github.com/sebastianbergmann/phpunit/issues/4259