### PR TITLE
XDebug: Fix code coverage toggle detection to support XDebug 3

### DIFF
--- a/src/Driver/XdebugDriver.php
+++ b/src/Driver/XdebugDriver.php
@@ -32,7 +32,11 @@ final class XdebugDriver extends Driver
             throw new XdebugNotAvailableException;
         }
 
-        if (!\ini_get('xdebug.coverage_enable')) {
+        if (\version_compare(\phpversion('xdebug'), '3', '>=')) {
+            if (!\ini_get('xdebug.mode') || \ini_get('xdebug.mode') !== 'coverage') {
+                throw new XdebugNotEnabledException(true);
+            }
+        } elseif (!\ini_get('xdebug.coverage_enable')) {
             throw new XdebugNotEnabledException;
         }
 

--- a/src/Exception/XdebugNotEnabledException.php
+++ b/src/Exception/XdebugNotEnabledException.php
@@ -13,8 +13,12 @@ use SebastianBergmann\CodeCoverage\Exception;
 
 final class XdebugNotEnabledException extends \RuntimeException implements Exception
 {
-    public function __construct()
+    public function __construct($mode_error = false)
     {
-        parent::__construct('xdebug.coverage_enable=On has to be set in php.ini');
+        if ($mode_error) {
+            parent::__construct('xdebug.mode=coverage has to be set in php.ini');
+        } else {
+            parent::__construct('xdebug.coverage_enable=On has to be set in php.ini');
+        }
     }
 }


### PR DESCRIPTION
XDebug 3 has "modes" feature, and removes the various toggles it has in its 2.x series. This PR changes the way code-coverage readiness is asserted, and throws an appropriate exception message. 

I'm using xdebug 3 for testing, and came across this error, hence this PR. However, I would totally understand if this is not merged until XDebug is GA.

Thank you.