### PR TITLE
Fix escaping in PHP serialization

### DIFF
--- a/src/Report/PHP.php
+++ b/src/Report/PHP.php
@@ -23,7 +23,7 @@ final class PHP
         $buffer = \sprintf(
             '<?php
 return \unserialize(\'%s\');',
-            \serialize($coverage)
+            \addcslashes(\serialize($coverage), "'")
         );
 
         if ($target !== null) {


### PR DESCRIPTION
Hello @sebastianbergmann 

Quick fix for an issue I noticed during testing, sometimes the coverage data contains strings like `eval'd code`. These quotes need to be escaped inside the PHP output, or the file is not valid PHP.