### PR TITLE
Explicitly ignore lines containing Class/Trait/Interface tokens (again)

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -563,8 +563,6 @@ final class CodeCoverage
 
                     break;
 
-                 // Intentional fallthrough
-
                 case PHP_Token_INTERFACE::class:
                 case PHP_Token_TRAIT::class:
                 case PHP_Token_CLASS::class:

--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -566,6 +566,8 @@ final class CodeCoverage
                 case PHP_Token_INTERFACE::class:
                 case PHP_Token_TRAIT::class:
                 case PHP_Token_CLASS::class:
+                    $this->ignoredLines[$fileName][] = $token->getLine(); //work around https://bugs.xdebug.org/view.php?id=1798
+                // Intentional fallthrough
                 case PHP_Token_FUNCTION::class:
                     /* @var \PHP_Token_Interface $token */
 

--- a/tests/tests/BuilderTest.php
+++ b/tests/tests/BuilderTest.php
@@ -156,11 +156,11 @@ final class BuilderTest extends TestCase
         $expectedPath = rtrim(TEST_FILES_PATH, DIRECTORY_SEPARATOR);
         $this->assertEquals($expectedPath, $root->name());
         $this->assertEquals($expectedPath, $root->pathAsString());
-        $this->assertEquals(2, $root->numberOfExecutableLines());
+        $this->assertEquals(1, $root->numberOfExecutableLines());
         $this->assertEquals(0, $root->numberOfExecutedLines());
         $data         = $coverage->getData()->lineCoverage();
         $expectedFile = $expectedPath . DIRECTORY_SEPARATOR . 'Crash.php';
-        $this->assertSame([$expectedFile => [1 => [], 2 => []]], $data);
+        $this->assertSame([$expectedFile => [1 => []]], $data);
     }
 
     public function testBuildDirectoryStructure(): void

--- a/tests/tests/CodeCoverageTest.php
+++ b/tests/tests/CodeCoverageTest.php
@@ -143,10 +143,12 @@ final class CodeCoverageTest extends TestCase
                 14,
                 15,
                 16,
+                18,
                 23,
                 24,
                 25,
                 30,
+                33,
             ],
             $this->getLinesToBeIgnored()->invoke(
                 $this->coverage,
@@ -169,7 +171,9 @@ final class CodeCoverageTest extends TestCase
     public function testGetLinesToBeIgnored3(): void
     {
         $this->assertEquals(
-            [],
+            [
+                3,
+            ],
             $this->getLinesToBeIgnored()->invoke(
                 $this->coverage,
                 TEST_FILES_PATH . 'source_with_class_and_anonymous_function.php'
@@ -181,6 +185,8 @@ final class CodeCoverageTest extends TestCase
     {
         $this->assertEquals(
             [
+                4,
+                9,
                 29,
                 31,
                 32,


### PR DESCRIPTION
For #774 

In currently released versions of php-code-coverage `CodeCoverage->getLinesToBeIgnoredInner()` is called for every file included in the whitelist. This was shared logic between files that were actually processed by a driver and uncovered files that were not. This had the effect that all files passed through our own version of an executable-code detector, which removed lines with class declarations.

In #757, this was refactored so that the inbuilt executable-code detector was only used for uncovered added files. For processed files, the driver's implementation is relied on.

However fixing that issue has revealed https://bugs.xdebug.org/view.php?id=1798 which was previously hidden. Depending on the precise execution path of the test suite, under Xdebug the class declaration in the affected files can show up as (1) non-executable (2) executable but covered by the first test that uses it (3) executable but uncovered. PCOV and PHPDBG are unaffected and always have behaviour (1).

This PR is a small partial revert of #757 to make class declarations always considered non-executable again regardless of what the driver data says.