### PR TITLE
Check for xdebug.mode values from a comma separated string

### DIFF
--- a/src/Driver/Xdebug3Driver.php
+++ b/src/Driver/Xdebug3Driver.php
@@ -51,7 +51,7 @@ final class Xdebug3Driver extends Driver
             );
         }
 
-        if (!ini_get('xdebug.mode') || ini_get('xdebug.mode') !== 'coverage') {
+        if (!\ini_get('xdebug.mode') || !\in_array('coverage', explode(',', ini_get('xdebug.mode')))) {
             throw new Xdebug3NotEnabledException;
         }
 


### PR DESCRIPTION
This change is needed so that it is possible to profile PHP running PHPUnit with code coverage