### PR TITLE
Branch/path render tweaks

### DIFF
--- a/src/Report/Html/Renderer/File.php
+++ b/src/Report/Html/Renderer/File.php
@@ -650,10 +650,15 @@ final class File extends Renderer
                 continue;
             }
 
-            $branches .= '<h5 class="structure-heading"><a name="' . htmlspecialchars($methodName, $this->htmlSpecialCharsFlags) . '">' . $this->abbreviateMethodName($methodName) . '</a></h5>' . "\n";
+            $branchStructure = '';
 
             foreach ($methodData['branches'] as $branch) {
-                $branches .= $this->renderBranchLines($branch, $codeLines, $testData);
+                $branchStructure .= $this->renderBranchLines($branch, $codeLines, $testData);
+            }
+
+            if ($branchStructure !== '') { // don't show empty branches
+                $branches .= '<h5 class="structure-heading"><a name="' . htmlspecialchars($methodName, $this->htmlSpecialCharsFlags) . '">' . $this->abbreviateMethodName($methodName) . '</a></h5>' . "\n";
+                $branches .= $branchStructure;
             }
         }
 
@@ -720,6 +725,10 @@ final class File extends Renderer
             $lines .= $this->renderLine($singleLineTemplate, $line, $codeLines[$line - 1], $trClass, $popover);
         }
 
+        if ($lines === '') {
+            return '';
+        }
+
         $linesTemplate->setVar(['lines' => $lines]);
 
         return $linesTemplate->render();
@@ -741,16 +750,21 @@ final class File extends Renderer
                 continue;
             }
 
-            $paths .= '<h5 class="structure-heading"><a name="' . htmlspecialchars($methodName, $this->htmlSpecialCharsFlags) . '">' . $this->abbreviateMethodName($methodName) . '</a></h5>' . "\n";
+            $pathStructure = '';
 
             if (count($methodData['paths']) > 100) {
-                $paths .= '<p>' . count($methodData['paths']) . ' is too many paths to sensibly render, consider refactoring your code to bring this number down.</p>';
+                $pathStructure .= '<p>' . count($methodData['paths']) . ' is too many paths to sensibly render, consider refactoring your code to bring this number down.</p>';
 
                 continue;
             }
 
             foreach ($methodData['paths'] as $path) {
-                $paths .= $this->renderPathLines($path, $methodData['branches'], $codeLines, $testData);
+                $pathStructure .= $this->renderPathLines($path, $methodData['branches'], $codeLines, $testData);
+            }
+
+            if ($pathStructure !== '') {
+                $paths .= '<h5 class="structure-heading"><a name="' . htmlspecialchars($methodName, $this->htmlSpecialCharsFlags) . '">' . $this->abbreviateMethodName($methodName) . '</a></h5>' . "\n";
+                $paths .= $pathStructure;
             }
         }
 
@@ -817,6 +831,10 @@ final class File extends Renderer
 
                 $lines .= $this->renderLine($singleLineTemplate, $line, $codeLines[$line - 1], $trClass, $popover);
             }
+        }
+
+        if ($lines === '') {
+            return '';
         }
 
         $linesTemplate->setVar(['lines' => $lines]);

--- a/src/Report/Html/Renderer/File.php
+++ b/src/Report/Html/Renderer/File.php
@@ -490,7 +490,7 @@ final class File extends Renderer
 
                     if ($branch['hit']) {
                         $lineData[$line]['includedInHitBranches']++;
-                        $lineData[$line]['tests'] = array_merge($lineData[$line]['tests'], $branch['hit']);
+                        $lineData[$line]['tests'] = array_unique(array_merge($lineData[$line]['tests'], $branch['hit']));
                     }
                 }
             }
@@ -577,7 +577,7 @@ final class File extends Renderer
 
                         if ($path['hit']) {
                             $lineData[$line]['includedInHitPaths']++;
-                            $lineData[$line]['tests'] = array_merge($lineData[$line]['tests'], $path['hit']);
+                            $lineData[$line]['tests'] = array_unique(array_merge($lineData[$line]['tests'], $path['hit']));
                         }
                     }
                 }

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_branch.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_branch.html
@@ -393,12 +393,6 @@
 
 </tbody>
 </table>
-<h5 class="structure-heading"><a name="{main}">{main}</a></h5>
-<table id="code" class="table table-borderless table-condensed">
-<tbody>
-
-</tbody>
-</table>
 
 
    <footer>

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_path.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_path.html
@@ -386,12 +386,6 @@
 
 </tbody>
 </table>
-<h5 class="structure-heading"><a name="{main}">{main}</a></h5>
-<table id="code" class="table table-borderless table-condensed">
-<tbody>
-
-</tbody>
-</table>
 
 
    <footer>


### PR DESCRIPTION
Hi @sebastianbergmann 

This PR fixes a couple of small issues I've noticed while doing further testing on branch/path coverage.

1) Sometimes there is an empty branch (e.g. the blank line at the end of a file), these can be safely skipped over
2) Lines that contain multiple branches within them are having tests double-counted inside the popup

