### PR TITLE
Unconditionally add testCaseId to speed up code coverage massively

### DIFF
--- a/src/ProcessedCodeCoverageData.php
+++ b/src/ProcessedCodeCoverageData.php
@@ -69,9 +69,7 @@ final class ProcessedCodeCoverageData
         foreach ($executedCode->lineCoverage() as $file => $lines) {
             foreach ($lines as $k => $v) {
                 if ($v === Driver::LINE_EXECUTED) {
-                    if (empty($this->lineCoverage[$file][$k]) || !in_array($testCaseId, $this->lineCoverage[$file][$k], true)) {
-                        $this->lineCoverage[$file][$k][] = $testCaseId;
-                    }
+                    $this->lineCoverage[$file][$k][] = $testCaseId;
                 }
             }
         }


### PR DESCRIPTION
With this change, both PHP Code Coverage's **and** PHPUnit's test suite still passes.
It makes the PHPUnit test suite run in approximately ⅔rds of the time, with no differences in output:

![output-diff](https://user-images.githubusercontent.com/208074/88484713-87cb0880-cf68-11ea-9ed3-0260a2d7028b.png)

PHPUnit's test suite (`$ php -dxdebug.mode=coverage,profile -dxdebug.start_with_request=yes -dhtml_errors=0 -dmemory_limit=2G ./phpunit --testsuite=unit --coverage-html=/tmp/cov-after.html`):

- Before: `Time: 00:52.085, Memory: 82.00 MB`
- After: `Time: 00:33.547, Memory: 82.00 MB`, a reduction of **36%**.

The valgrind/cachegrind profile shows it is using only **27%** of its previous instructions.

```
/tmp/callgrind.phpunit-coverage.2020-07-25-02-profile-refs.before-pr.out: totals: 178 198 995 103
/tmp/callgrind.phpunit-coverage.2020-07-25-02-profile-refs.out:totals:             48 225 236 059
```
