### PR TITLE
fixed namespace handling from removing more than the tail.

### DIFF
--- a/src/StaticAnalysis/CodeUnitFindingVisitor.php
+++ b/src/StaticAnalysis/CodeUnitFindingVisitor.php
@@ -10,7 +10,6 @@
 namespace SebastianBergmann\CodeCoverage\StaticAnalysis;
 
 use function implode;
-use function str_replace;
 use function trim;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
@@ -285,13 +284,6 @@ final class CodeUnitFindingVisitor extends NodeVisitorAbstract
 
     private function namespace(string $namespacedName, string $name): string
     {
-        return trim(
-            str_replace(
-                $name,
-                '',
-                $namespacedName
-            ),
-            '\\'
-        );
+        return trim(rtrim($namespacedName, $name), '\\');
     }
 }

--- a/tests/_files/ClassThatUsesAnonymousClass.php
+++ b/tests/_files/ClassThatUsesAnonymousClass.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-namespace SebastianBergmann\CodeCoverage\TestFixture;
+namespace SebastianBergmann\CodeCoverage\ClassThatUsesAnonymousClass\TestFixture;
 
 final class ClassThatUsesAnonymousClass
 {

--- a/tests/tests/StaticAnalysis/CodeUnitFindingVisitorTest.php
+++ b/tests/tests/StaticAnalysis/CodeUnitFindingVisitorTest.php
@@ -15,7 +15,7 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
-use SebastianBergmann\CodeCoverage\TestFixture\ClassThatUsesAnonymousClass;
+use SebastianBergmann\CodeCoverage\ClassThatUsesAnonymousClass\TestFixture\ClassThatUsesAnonymousClass;
 
 /**
  * @covers \SebastianBergmann\CodeCoverage\StaticAnalysis\CodeUnitFindingVisitor
@@ -55,7 +55,7 @@ final class CodeUnitFindingVisitorTest extends TestCase
 
         $this->assertSame('ClassThatUsesAnonymousClass', $class['name']);
         $this->assertSame(ClassThatUsesAnonymousClass::class, $class['namespacedName']);
-        $this->assertSame('SebastianBergmann\CodeCoverage\TestFixture', $class['namespace']);
+        $this->assertSame('SebastianBergmann\CodeCoverage\ClassThatUsesAnonymousClass\TestFixture', $class['namespace']);
         $this->assertSame(4, $class['startLine']);
         $this->assertSame(17, $class['endLine']);
 


### PR DESCRIPTION
namespace handling is stripping more than the tail, causing 

unserialize(): Error at offset 209854 of 284023 bytes

[ 
"name" => "Daemon", 
"namespacedName" => "Foo\Infrastructure\Daemon\Watchdog\Daemon", 
"namespace" => "Foo\Infrastructure\\Watchdog";
...]
