### PR TITLE
Force empty lines non executable

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -162,6 +162,8 @@ final class CodeCoverage
      */
     public function getData(bool $raw = false): ProcessedCodeCoverageData
     {
+        $this->data->finalize();
+
         if (!$raw) {
             if ($this->processUncoveredFiles) {
                 $this->processUncoveredFilesFromFilter();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1122,48 +1122,48 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return [
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
-                    14 => 1,
-                    15 => -2,
+                    13 => 1,
+                    14 => -2,
+                    18 => -1,
                     19 => -1,
                     20 => -1,
                     21 => -1,
-                    22 => -1,
-                    24 => -1,
-                    28 => -1,
-                    30 => -1,
-                    31 => -2,
-                    35 => -1,
-                    37 => -1,
-                    38 => -2,
+                    23 => -1,
+                    27 => -1,
+                    29 => -1,
+                    30 => -2,
+                    34 => -1,
+                    36 => -1,
+                    37 => -2,
                 ],
             ]),
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
-                    14 => 1,
-                    19 => 1,
-                    22 => 1,
-                    35 => 1,
+                    13 => 1,
+                    18 => 1,
+                    21 => 1,
+                    34 => 1,
                 ],
             ]),
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
-                    14 => 1,
-                    19 => 1,
-                    22 => 1,
-                    28 => 1,
+                    13 => 1,
+                    18 => 1,
+                    21 => 1,
+                    27 => 1,
                 ],
             ]),
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'NamespacedBankAccount.php' => [
-                    14 => 1,
+                    13 => 1,
+                    18 => 1,
                     19 => 1,
                     20 => 1,
-                    21 => 1,
-                    24 => 1,
-                    28 => 1,
-                    30 => 1,
-                    35 => 1,
-                    37 => 1,
+                    23 => 1,
+                    27 => 1,
+                    29 => 1,
+                    34 => 1,
+                    36 => 1,
                 ],
             ]),
         ];
@@ -1190,7 +1190,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         $coverage->stop(
             true,
-            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => range(12, 15)]
+            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => range(11, 14)]
         );
 
         $coverage->start(
@@ -1199,7 +1199,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         $coverage->stop(
             true,
-            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => range(33, 38)]
+            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => range(32, 37)]
         );
 
         $coverage->start(
@@ -1208,7 +1208,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         $coverage->stop(
             true,
-            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => range(26, 31)]
+            [TEST_FILES_PATH . 'NamespacedBankAccount.php' => range(25, 30)]
         );
 
         $coverage->start(
@@ -1219,9 +1219,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             true,
             [
                 TEST_FILES_PATH . 'NamespacedBankAccount.php' => array_merge(
-                    range(12, 15),
-                    range(26, 31),
-                    range(33, 38)
+                    range(11, 14),
+                    range(25, 30),
+                    range(32, 37)
                 ),
             ]
         );

--- a/tests/_files/NamespacedBankAccount-text.txt
+++ b/tests/_files/NamespacedBankAccount-text.txt
@@ -11,4 +11,4 @@ Code Coverage Report:
 SomeNamespace\BankAccount
   Methods:  ( 0/ 0)   Lines:  (  0/  0)
 SomeNamespace\BankAccountTrait
-  Methods:  75.00% ( 3/ 4)   Lines:  55.56% (  5/  9)
+  Methods:  75.00% ( 3/ 4)   Lines:  50.00% (  5/ 10)


### PR DESCRIPTION
To hopefully fix #799

This isn't quite the same concept as an "ignored line" so I've deliberately kept this implementation distinct from the static analysis code. It's done as a single pass at the end of execution for speed, although it also simplifies the code.