### PR TITLE
Empty lines not executable v2

### DIFF
--- a/src/RawCodeCoverageData.php
+++ b/src/RawCodeCoverageData.php
@@ -27,6 +27,11 @@ use SebastianBergmann\CodeCoverage\StaticAnalysis\UncoveredFileAnalyser;
 final class RawCodeCoverageData
 {
     /**
+     * @var array<string, array<int>>
+     */
+    private static $emptyLineCache = [];
+
+    /**
      * @var array
      *
      * @see https://xdebug.org/docs/code_coverage for format
@@ -94,6 +99,8 @@ final class RawCodeCoverageData
     {
         $this->lineCoverage     = $lineCoverage;
         $this->functionCoverage = $functionCoverage;
+
+        $this->skipEmptyLines();
     }
 
     public function clear(): void
@@ -180,5 +187,41 @@ final class RawCodeCoverageData
                 }
             }
         }
+    }
+
+    /**
+     * At the end of a file, the PHP interpreter always sees an implicit return. Where this occurs in a file that has
+     * e.g. a class definition, that line cannot be invoked from a test and results in confusing coverage. This engine
+     * implementation detail therefore needs to be masked which is done here by simply ensuring that all empty lines
+     * are skipped over for coverage purposes.
+     *
+     * @see https://github.com/sebastianbergmann/php-code-coverage/issues/799
+     */
+    private function skipEmptyLines(): void
+    {
+        foreach ($this->lineCoverage as $filename => $coverage) {
+            foreach ($this->getEmptyLinesForFile($filename) as $emptyLine) {
+                unset($this->lineCoverage[$filename][$emptyLine]);
+            }
+        }
+    }
+
+    private function getEmptyLinesForFile(string $filename): array
+    {
+        if (!isset(self::$emptyLineCache[$filename])) {
+            self::$emptyLineCache[$filename] = [];
+
+            if (is_file($filename)) {
+                $sourceLines = explode("\n", file_get_contents($filename));
+
+                foreach ($sourceLines as $line => $source) {
+                    if (trim($source) === '') {
+                        self::$emptyLineCache[$filename][] = ($line + 1);
+                    }
+                }
+            }
+        }
+
+        return self::$emptyLineCache[$filename];
     }
 }

--- a/tests/tests/RawCodeCoverageDataTest.php
+++ b/tests/tests/RawCodeCoverageDataTest.php
@@ -439,7 +439,6 @@ final class RawCodeCoverageDataTest extends TestCase
                 26 => -1,
                 35 => -1,
                 36 => -1,
-                37 => -1,
             ],
             $coverage->lineCoverage()[$filename]
         );


### PR DESCRIPTION
#799, version 2

This version moves the skip logic from the very end of the process to the very beginning 🤞 that should cover all potential scenarios. This has been tested on #799 (no line 14) and sebastian/code-unit (no risky tests).

This is using a static array cache rather than the static analysis file cache because the file cache is predicated around filenames and methods, but the problem in #799 is lines that are completely outside of a method so those cache keys don't fit the usecase. The analysis itself is also fairly cheap so there's less benefit from persisting that across runs than the more advanced PHP-Parser based analyses so I think that should be OK.