### PR TITLE
Add Cobertura report format

### DIFF
--- a/src/Report/Cobertura.php
+++ b/src/Report/Cobertura.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Report;
+
+use function count;
+use function dirname;
+use function file_put_contents;
+use function max;
+use function range;
+use function time;
+use DOMImplementation;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Directory;
+use SebastianBergmann\CodeCoverage\Driver\WriteOperationFailedException;
+use SebastianBergmann\CodeCoverage\Node\File;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Cobertura
+{
+    /**
+     * @throws WriteOperationFailedException
+     */
+    public function process(CodeCoverage $coverage, ?string $target = null, ?string $name = null): string
+    {
+        $time = (string) time();
+
+        $report = $coverage->getReport();
+
+        $impl = new DOMImplementation();
+        $dtd  = $impl->createDocumentType(
+            'coverage',
+            '',
+            'http://cobertura.sourceforge.net/xml/coverage-04.dtd'
+        );
+
+        $xmlDocument               = $impl->createDocument('', '', $dtd);
+        $xmlDocument->xmlVersion   = '1.0';
+        $xmlDocument->encoding     = 'UTF-8';
+        $xmlDocument->formatOutput = true;
+
+        $xmlCoverage = $xmlDocument->createElement('coverage');
+
+        // Line rate.
+        $linesValid   = $report->numberOfExecutedLines();
+        $linesCovered = $report->numberOfExecutableLines();
+        $lineRate     = $linesValid === 0 ? 0 : ($linesCovered / $linesValid);
+        $xmlCoverage->setAttribute('line-rate', (string) $lineRate);
+
+        // Branch rate.
+        $branchesValid   = $report->numberOfExecutedBranches();
+        $branchesCovered = $report->numberOfExecutableBranches();
+        $branchRate      = $branchesValid === 0 ? 0 : ($branchesCovered / $branchesValid);
+        $xmlCoverage->setAttribute('branch-rate', (string) $branchRate);
+
+        $xmlCoverage->setAttribute('lines-covered', (string) $report->numberOfExecutedLines());
+        $xmlCoverage->setAttribute('lines-valid', (string) $report->numberOfExecutableLines());
+        $xmlCoverage->setAttribute('branches-covered', (string) $report->numberOfExecutedBranches());
+        $xmlCoverage->setAttribute('branches-valid', (string) $report->numberOfExecutableBranches());
+        $xmlCoverage->setAttribute('complexity', '');
+        $xmlCoverage->setAttribute('version', '0.4');
+        $xmlCoverage->setAttribute('timestamp', $time);
+        $xmlDocument->appendChild($xmlCoverage);
+
+        $xmlSources = $xmlDocument->createElement('sources');
+        $xmlCoverage->appendChild($xmlSources);
+
+        $xmlSource = $xmlDocument->createElement('source', $report->pathAsString());
+        $xmlSources->appendChild($xmlSource);
+
+        $xmlPackages = $xmlDocument->createElement('packages');
+        $xmlCoverage->appendChild($xmlPackages);
+
+        $complexity = 0;
+
+        foreach ($report as $item) {
+            if (!$item instanceof File) {
+                continue;
+            }
+
+            $packageComplexity = 0;
+
+            $xmlPackage = $xmlDocument->createElement('package');
+
+            $packageName = '';
+
+            if ($name !== null) {
+                $packageName = $name;
+            }
+            $xmlPackage->setAttribute('name', $packageName);
+
+            $linesValid   = $item->numberOfExecutableLines();
+            $linesCovered = $item->numberOfExecutedLines();
+            $lineRate     = $linesValid === 0 ? 0 : ($linesCovered / $linesValid);
+            $xmlPackage->setAttribute('line-rate', (string) $lineRate);
+
+            $branchesValid   = $item->numberOfExecutableBranches();
+            $branchesCovered = $item->numberOfExecutedBranches();
+            $branchRate      = $branchesValid === 0 ? 0 : ($branchesCovered / $branchesValid);
+            $xmlPackage->setAttribute('branch-rate', (string) $branchRate);
+
+            $xmlPackage->setAttribute('complexity', '');
+            $xmlPackages->appendChild($xmlPackage);
+
+            $xmlClasses = $xmlDocument->createElement('classes');
+            $xmlPackage->appendChild($xmlClasses);
+
+            $classes      = $item->classesAndTraits();
+            $coverageData = $item->lineCoverageData();
+
+            foreach ($classes as $className => $class) {
+                $complexity += $class['ccn'];
+                $packageComplexity += $class['ccn'];
+
+                if (!empty($class['package']['namespace'])) {
+                    $className = $class['package']['namespace'] . '\\' . $className;
+                }
+
+                $linesValid   = $class['executableLines'];
+                $linesCovered = $class['executedLines'];
+                $lineRate     = $linesValid === 0 ? 0 : ($linesCovered / $linesValid);
+
+                $branchesValid   = $class['executableBranches'];
+                $branchesCovered = $class['executedBranches'];
+                $branchRate      = $branchesValid === 0 ? 0 : ($branchesCovered / $branchesValid);
+
+                $xmlClass = $xmlDocument->createElement('class');
+                $xmlClass->setAttribute('name', $className);
+                $xmlClass->setAttribute('filename', str_replace($report->pathAsString() . '/', '', $item->pathAsString()));
+                $xmlClass->setAttribute('line-rate', (string) $lineRate);
+                $xmlClass->setAttribute('branch-rate', (string) $branchRate);
+                $xmlClass->setAttribute('complexity', (string) $class['ccn']);
+                $xmlClasses->appendChild($xmlClass);
+
+                $xmlMethods = $xmlDocument->createElement('methods');
+                $xmlClass->appendChild($xmlMethods);
+
+                $xmlClassLines = $xmlDocument->createElement('lines');
+                $xmlClass->appendChild($xmlClassLines);
+
+                foreach ($class['methods'] as $methodName => $method) {
+                    if ($method['executableLines'] == 0) {
+                        continue;
+                    }
+
+                    $methodCount = 0;
+
+                    foreach (range($method['startLine'], $method['endLine']) as $line) {
+                        if (isset($coverageData[$line]) && $coverageData[$line] !== null) {
+                            $methodCount = max($methodCount, count($coverageData[$line]));
+
+                            $xmlClassLine = $xmlDocument->createElement('line');
+                            $xmlClassLine->setAttribute('number', (string) $line);
+                            $xmlClassLine->setAttribute('hits', (string) count($coverageData[$line]));
+                            $xmlClassLines->appendChild($xmlClassLine);
+                        }
+                    }
+
+                    $linesValid   = $method['executableLines'];
+                    $linesCovered = $method['executedLines'];
+                    $lineRate     = $linesValid === 0 ? 0 : ($linesCovered / $linesValid);
+
+                    $branchesValid   = $method['executableBranches'];
+                    $branchesCovered = $method['executedBranches'];
+                    $branchRate      = $branchesValid === 0 ? 0 : ($branchesCovered / $branchesValid);
+
+                    $xmlMethod = $xmlDocument->createElement('method');
+                    $xmlMethod->setAttribute('name', $methodName);
+                    $xmlMethod->setAttribute('signature', $method['signature']);
+                    $xmlMethod->setAttribute('line-rate', (string) $lineRate);
+                    $xmlMethod->setAttribute('branch-rate', (string) $branchRate);
+                    $xmlMethod->setAttribute('complexity', (string) $method['ccn']);
+
+                    $xmlLines = $xmlDocument->createElement('lines');
+                    $xmlMethod->appendChild($xmlLines);
+
+                    $xmlLine = $xmlDocument->createElement('line');
+                    $xmlLine->setAttribute('number', (string) $method['startLine']);
+                    $xmlLine->setAttribute('hits', (string) $methodCount);
+                    $xmlLines->appendChild($xmlLine);
+
+                    $xmlMethods->appendChild($xmlMethod);
+                }
+            }
+
+            $xmlPackage->setAttribute('complexity', (string) $packageComplexity);
+        }
+
+        $xmlCoverage->setAttribute('complexity', (string) $complexity);
+
+        $buffer = $xmlDocument->saveXML();
+
+        if ($target !== null) {
+            Directory::create(dirname($target));
+
+            if (@file_put_contents($target, $buffer) === false) {
+                throw new WriteOperationFailedException($target);
+            }
+        }
+
+        return $buffer;
+    }
+}

--- a/tests/_files/BankAccount-cobertura-line.xml
+++ b/tests/_files/BankAccount-cobertura-line.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="2" branch-rate="0" lines-covered="5" lines-valid="10" branches-covered="0" branches-valid="0" complexity="5" version="0.4" timestamp="%i">
+  <sources>
+    <source>%s</source>
+  </sources>
+  <packages>
+    <package name="BankAccount" line-rate="0.5" branch-rate="0" complexity="5">
+      <classes>
+        <class name="BankAccount" filename="BankAccount.php" line-rate="0.5" branch-rate="0" complexity="5">
+          <methods>
+            <method name="getBalance" signature="getBalance()" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="6" hits="2"/>
+              </lines>
+            </method>
+            <method name="setBalance" signature="setBalance($balance)" line-rate="0" branch-rate="0" complexity="2">
+              <lines>
+                <line number="11" hits="0"/>
+              </lines>
+            </method>
+            <method name="depositMoney" signature="depositMoney($balance)" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="20" hits="2"/>
+              </lines>
+            </method>
+            <method name="withdrawMoney" signature="withdrawMoney($balance)" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="27" hits="2"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="8" hits="2"/>
+            <line number="13" hits="0"/>
+            <line number="14" hits="0"/>
+            <line number="15" hits="0"/>
+            <line number="16" hits="0"/>
+            <line number="18" hits="0"/>
+            <line number="22" hits="2"/>
+            <line number="24" hits="1"/>
+            <line number="29" hits="2"/>
+            <line number="31" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/_files/BankAccount-cobertura-path.xml
+++ b/tests/_files/BankAccount-cobertura-path.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="2" branch-rate="2.3333333333333" lines-covered="5" lines-valid="10" branches-covered="3" branches-valid="7" complexity="5" version="0.4" timestamp="%i">
+  <sources>
+    <source>%s</source>
+  </sources>
+  <packages>
+    <package name="BankAccount" line-rate="0.5" branch-rate="0.42857142857143" complexity="5">
+      <classes>
+        <class name="BankAccount" filename="BankAccount.php" line-rate="0.5" branch-rate="0.42857142857143" complexity="5">
+          <methods>
+            <method name="getBalance" signature="getBalance()" line-rate="1" branch-rate="1" complexity="1">
+              <lines>
+                <line number="6" hits="2"/>
+              </lines>
+            </method>
+            <method name="setBalance" signature="setBalance($balance)" line-rate="0" branch-rate="0" complexity="2">
+              <lines>
+                <line number="11" hits="0"/>
+              </lines>
+            </method>
+            <method name="depositMoney" signature="depositMoney($balance)" line-rate="1" branch-rate="1" complexity="1">
+              <lines>
+                <line number="20" hits="2"/>
+              </lines>
+            </method>
+            <method name="withdrawMoney" signature="withdrawMoney($balance)" line-rate="1" branch-rate="1" complexity="1">
+              <lines>
+                <line number="27" hits="2"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="8" hits="2"/>
+            <line number="13" hits="0"/>
+            <line number="14" hits="0"/>
+            <line number="15" hits="0"/>
+            <line number="16" hits="0"/>
+            <line number="18" hits="0"/>
+            <line number="22" hits="2"/>
+            <line number="24" hits="1"/>
+            <line number="29" hits="2"/>
+            <line number="31" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/_files/class-with-anonymous-function-cobertura.xml
+++ b/tests/_files/class-with-anonymous-function-cobertura.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="1.125" branch-rate="0" lines-covered="8" lines-valid="9" branches-covered="0" branches-valid="0" complexity="1" version="0.4" timestamp="%i">
+  <sources>
+    <source>%s</source>
+  </sources>
+  <packages>
+    <package name="" line-rate="0.88888888888889" branch-rate="0" complexity="1">
+      <classes>
+        <class name="CoveredClassWithAnonymousFunctionInStaticMethod" filename="source_with_class_and_anonymous_function.php" line-rate="0.88888888888889" branch-rate="0" complexity="1">
+          <methods>
+            <method name="runAnonymous" signature="runAnonymous()" line-rate="0.88888888888889" branch-rate="0" complexity="1">
+              <lines>
+                <line number="5" hits="1"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="7" hits="1"/>
+            <line number="9" hits="1"/>
+            <line number="10" hits="0"/>
+            <line number="11" hits="1"/>
+            <line number="12" hits="1"/>
+            <line number="13" hits="1"/>
+            <line number="14" hits="1"/>
+            <line number="17" hits="1"/>
+            <line number="18" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/_files/ignored-lines-cobertura.xml
+++ b/tests/_files/ignored-lines-cobertura.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="2" branch-rate="0" lines-covered="1" lines-valid="2" branches-covered="0" branches-valid="0" complexity="2" version="0.4" timestamp="%i">
+  <sources>
+    <source>%s</source>
+  </sources>
+  <packages>
+    <package name="" line-rate="0.5" branch-rate="0" complexity="2">
+      <classes>
+        <class name="Foo" filename="source_with_ignore.php" line-rate="0" branch-rate="0" complexity="1">
+          <methods/>
+          <lines/>
+        </class>
+        <class name="Bar" filename="source_with_ignore.php" line-rate="0" branch-rate="0" complexity="1">
+          <methods/>
+          <lines/>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/tests/CoberturaTest.php
+++ b/tests/tests/CoberturaTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Report;
+
+use SebastianBergmann\CodeCoverage\TestCase;
+
+/**
+ * @covers \SebastianBergmann\CodeCoverage\Report\Cobertura
+ */
+final class CoberturaTest extends TestCase
+{
+    public function testLineCoverageForBankAccountTest(): void
+    {
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccount-cobertura-line.xml',
+            $cobertura->process($this->getLineCoverageForBankAccount(), null, 'BankAccount')
+        );
+    }
+
+    public function testPathCoverageForBankAccountTest(): void
+    {
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccount-cobertura-path.xml',
+            $cobertura->process($this->getPathCoverageForBankAccount(), null, 'BankAccount')
+        );
+    }
+
+    public function testCoberturaForFileWithIgnoredLines(): void
+    {
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'ignored-lines-cobertura.xml',
+            $cobertura->process($this->getCoverageForFileWithIgnoredLines())
+        );
+    }
+
+    public function testCoberturaForClassWithAnonymousFunction(): void
+    {
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'class-with-anonymous-function-cobertura.xml',
+            $cobertura->process($this->getCoverageForClassWithAnonymousFunction())
+        );
+    }
+}


### PR DESCRIPTION
Updated version of #734 

I combined some work I had done originally with Rask's work.  The result should be fully compliant with the cobertura format dtd. 

The one problem I have not resolved is one that Rask noted that cobertura doesn't seem to support non-class based lines. I am not sure if this should even be a blocking issue, but I will check what some other test runners like Jest have done.