### PR TITLE
Add endLine in function coverage data

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -532,6 +532,7 @@ final class File extends AbstractNode
                 'namespace'          => $function['namespace'],
                 'signature'          => $function['signature'],
                 'startLine'          => $function['startLine'],
+                'endLine'            => $function['endLine'],
                 'executableLines'    => 0,
                 'executedLines'      => 0,
                 'executableBranches' => 0,


### PR DESCRIPTION
Coverage data for function does not have `'endLine'` but data is available. Adding it will be convenient to implement cevrage for non-class based line in Cobertura format (see https://github.com/sebastianbergmann/php-code-coverage/pull/812#issue-490624752)