### PR TITLE
Add support for non class based lines in cobertura

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -532,6 +532,7 @@ final class File extends AbstractNode
                 'namespace'          => $function['namespace'],
                 'signature'          => $function['signature'],
                 'startLine'          => $function['startLine'],
+                'endLine'            => $function['endLine'],
                 'executableLines'    => 0,
                 'executedLines'      => 0,
                 'executableBranches' => 0,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1728,6 +1728,41 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return $stub;
     }
 
+    protected function getCoverageForClassWithOutsideFunction(): CodeCoverage
+    {
+        $filter = new Filter;
+        $filter->includeFile(TEST_FILES_PATH . 'source_with_class_and_outside_function.php');
+
+        $coverage = new CodeCoverage(
+            $this->setUpXdebugStubForClassWithOutsideFunction(),
+            $filter
+        );
+
+        $coverage->start('ClassWithOutsideFunction', true);
+        $coverage->stop();
+
+        return $coverage;
+    }
+
+    protected function setUpXdebugStubForClassWithOutsideFunction(): Driver
+    {
+        $stub = $this->createStub(Driver::class);
+
+        $stub->method('stop')
+            ->willReturn(RawCodeCoverageData::fromXdebugWithoutPathCoverage(
+                [
+                    TEST_FILES_PATH . 'source_with_class_and_outside_function.php' => [
+                        6  => 1,
+                        12 => 1,
+                        13 => 1,
+                        16 => -1,
+                    ],
+                ]
+            ));
+
+        return $stub;
+    }
+
     protected function removeTemporaryFiles(): void
     {
         $tmpFilesIterator = new RecursiveIteratorIterator(

--- a/tests/_files/class-with-outside-function-cobertura.xml
+++ b/tests/_files/class-with-outside-function-cobertura.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="1.3333333333333" branch-rate="0" lines-covered="3" lines-valid="4" branches-covered="0" branches-valid="0" complexity="3" version="0.4" timestamp="%i">
+  <sources>
+    <source>%s</source>
+  </sources>
+  <packages>
+    <package name="" line-rate="0.75" branch-rate="0" complexity="3">
+      <classes>
+        <class name="ClassInFileWithOutsideFunction" filename="source_with_class_and_outside_function.php" line-rate="1" branch-rate="0" complexity="1">
+          <methods>
+            <method name="classMethod" signature="classMethod(): string" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="6" hits="1"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="6" hits="1"/>
+          </lines>
+        </class>
+        <class name="source_with_class_and_outside_function.php" filename="source_with_class_and_outside_function.php" line-rate="0.66666666666667" branch-rate="0" complexity="2">
+          <methods>
+            <method name="outsideFunction" signature="outsideFunction(bool $test): int" line-rate="0.66666666666667" branch-rate="0" complexity="2">
+              <lines>
+                <line number="12" hits="1"/>
+                <line number="13" hits="1"/>
+                <line number="16" hits="0"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="12" hits="1"/>
+            <line number="13" hits="1"/>
+            <line number="16" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/_files/source_with_class_and_outside_function.php
+++ b/tests/_files/source_with_class_and_outside_function.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+class ClassInFileWithOutsideFunction
+{
+   public static function classMethod(): string
+   {
+       return self::class;
+   }
+}
+
+function outsideFunction(bool $test): int
+{
+    if ($test) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/tests/CoberturaTest.php
+++ b/tests/tests/CoberturaTest.php
@@ -55,4 +55,14 @@ final class CoberturaTest extends TestCase
             $cobertura->process($this->getCoverageForClassWithAnonymousFunction())
         );
     }
+
+    public function testCoberturaForClassAndOutsideFunction(): void
+    {
+        $cobertura = new Cobertura;
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'class-with-outside-function-cobertura.xml',
+            $cobertura->process($this->getCoverageForClassWithOutsideFunction())
+        );
+    }
 }


### PR DESCRIPTION
This PR adds support for functions outside a class for Cobertura reports.

This is based on what is done by `coverage.py` in Python. I looks like Jest does add coverage for function outside classes in cobertura reports but I this it is better to add it in this package.