### PR TITLE
count on null php7 fix for #ef7b2f5 4.0.8

### DIFF
--- a/src/Report/Html/Renderer/File.php
+++ b/src/Report/Html/Renderer/File.php
@@ -304,7 +304,7 @@ class File extends Renderer
             $popoverTitle   = '';
 
             if (array_key_exists($i, $coverageData)) {
-                $numTests = count($coverageData[$i]);
+                $numTests = is_null($coverageData[$i]) ? 0 : count($coverageData[$i]);
 
                 if ($coverageData[$i] === null) {
                     $trClass = ' class="warning"';


### PR DESCRIPTION
Hello there,

If we refer to the infos the version of phpunit 5.* must be compatible with php 7.* Outside phpunit 5.* uses the version php-code-coverage 4.* which has a typo at line 307 of the file src/Report/Html/Renderer/File.php.

Used, in my case with php 7.4, this error occurs :

> Generating code coverage report in HTML format ...PHP Warning: count(): Parameter must be an array or an object that implements Countable in /mnt/data/files/dev/wam/casting-kingdom/vendor/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php online 307

Because $coverageData[$i] contains null is not countable .

Here is a fix, functional and tested to release a nice version 4.0.9 compatible ...

Thanks in advance :)