### PR TITLE
Allow version 4 of php-token-stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-dom": "*",
         "ext-xmlwriter": "*",
         "phpunit/php-file-iterator": "^2.0.2",
-        "phpunit/php-token-stream": "^3.1.1",
+        "phpunit/php-token-stream": "^3.1.1 || ^4.0",
         "phpunit/php-text-template": "^1.2.1",
         "sebastian/code-unit-reverse-lookup": "^1.0.1",
         "sebastian/environment": "^4.2.2",


### PR DESCRIPTION
Since PHPUnit 8.5 is supposed to work on both PHP 7 and PHP 8, I think we need to allow version 4 of phpunit/php-token-stream to prevent the following error:

```
Error: Class "PHP_Token_NAME_QUALIFIED" not found
```

Support for `NAME_QUALIFIED` has only been added in [version 4.0.4](https://github.com/sebastianbergmann/php-token-stream/blob/master/ChangeLog.md#added), however, this version is not allowed here yet.

Another possible solution would be to allow php-code-coverage version 8 in PHPUnit 8.5, but I figured that this change might have less side-effects. @sebastianbergmann If you prefer the other solution, I'll happily create a new PR. ;)
