### PR TITLE
Fixing memory usage issues when generating report (#842)

### DIFF
--- a/src/Report/PHP.php
+++ b/src/Report/PHP.php
@@ -12,20 +12,25 @@ namespace SebastianBergmann\CodeCoverage\Report;
 use function addcslashes;
 use function dirname;
 use function file_put_contents;
+use function min;
 use function serialize;
 use function sprintf;
+use function strlen;
+use function substr;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Directory;
 use SebastianBergmann\CodeCoverage\Driver\WriteOperationFailedException;
 
 final class PHP
 {
+    private const BATCH_SIZE = 1000000;
+
     public function process(CodeCoverage $coverage, ?string $target = null): string
     {
         $buffer = sprintf(
             '<?php
 return \unserialize(\'%s\');',
-            addcslashes(serialize($coverage), "'")
+            $this->serialize($coverage)
         );
 
         if ($target !== null) {
@@ -37,5 +42,21 @@ return \unserialize(\'%s\');',
         }
 
         return $buffer;
+    }
+
+    private function serialize(CodeCoverage $coverage): string
+    {
+        $serialized = serialize($coverage);
+        $length     = strlen($serialized);
+        $result     = '';
+
+        // Aiming to use less memory by escaping string in batches as addcslashes() seems to require
+        // 4-5x the size of string parameter being escaped
+        for ($i = 0; $i < $length; $i += self::BATCH_SIZE) {
+            $batch = substr($serialized, $i, min(self::BATCH_SIZE, $length - $i));
+            $result .= addcslashes($batch, "'");
+        }
+
+        return $result;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1029,6 +1029,50 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return $coverage;
     }
 
+    protected function getLineCoverageForBankAccountByPoints(int $points): CodeCoverage
+    {
+        $data = RawCodeCoverageData::fromXdebugWithoutPathCoverage([
+            TEST_FILES_PATH . 'BankAccount.php' => [
+                8  => 1,
+                13 => 1,
+                14 => 1,
+                15 => 1,
+                18 => 1,
+                22 => 1,
+                24 => 1,
+                29 => 1,
+                31 => 1,
+            ],
+        ]);
+
+        $stub = $this->createStub(Driver::class);
+        $stub->method('stop')
+             ->willReturn($data);
+
+        $filter = new Filter;
+        $filter->includeFile(TEST_FILES_PATH . 'BankAccount.php');
+
+        $coverage = new CodeCoverage($stub, $filter);
+
+        for ($i = 0; $i < $points; $i++) {
+            $coverage->start(
+                uniqid(),
+                ($i === 0)
+            );
+
+            $coverage->stop(
+                true,
+                [
+                    TEST_FILES_PATH . 'BankAccount.php' => array_merge(
+                        range(rand(0, 15), rand(16, 34))
+                    ),
+                ]
+            );
+        }
+
+        return $coverage;
+    }
+
     protected function getPathCoverageForBankAccount(): CodeCoverage
     {
         $data = $this->getPathCoverageXdebugDataForBankAccount();

--- a/tests/tests/PhpTest.php
+++ b/tests/tests/PhpTest.php
@@ -31,4 +31,27 @@ final class PhpTest extends TestCase
 
         $this->assertEquals($coverage, $unserialized);
     }
+
+    public function testMemoryUsage(): void
+    {
+        // Approx 75MB when serialized
+        $coverage   = $this->getLineCoverageForBankAccountByPoints(100000);
+        $serialized = serialize($coverage);
+        $size       = strlen($serialized);
+
+        // Using memory_get_peak_usage() to determine if memory has been optimised so approximately
+        // filling memory up to current measured peak usage allowing us to get a more accurate peak
+        // usage value when measuring process() memory usage
+        $memFill = str_repeat('a', memory_get_peak_usage(true) - memory_get_usage(true));
+
+        $before = memory_get_peak_usage(true);
+        /* @noinspection UnusedFunctionResultInspection */
+        (new PHP)->process($coverage, self::$TEST_TMP_PATH . '/serialized.php');
+        $after = memory_get_peak_usage(true);
+
+        // Max memory used should be up to 3 x serialized size (however doesn't scale when string increases in size)
+        $this->assertLessThan($size * 3, $after - $before);
+        // Temporary usage of fill
+        $this->assertNotNull($memFill);
+    }
 }


### PR DESCRIPTION
Batching serialized `CodeCoverage` so that less memory is required when generating escaped string via `addcslashes()` method.