### PR TITLE
Use a nowdoc instead of escaping the serialized string. Fixes #842

### DIFF
--- a/src/Report/PHP.php
+++ b/src/Report/PHP.php
@@ -9,7 +9,6 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report;
 
-use function addcslashes;
 use function dirname;
 use function file_put_contents;
 use function serialize;
@@ -23,9 +22,12 @@ final class PHP
     public function process(CodeCoverage $coverage, ?string $target = null): string
     {
         $buffer = sprintf(
-            '<?php
-return \unserialize(\'%s\');',
-            addcslashes(serialize($coverage), "'")
+            "<?php
+return \unserialize(<<<'END_OF_COVERAGE_SERIALIZATION'%s%s%sEND_OF_COVERAGE_SERIALIZATION%s);",
+            PHP_EOL,
+            serialize($coverage),
+            PHP_EOL,
+            PHP_EOL
         );
 
         if ($target !== null) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1688,6 +1688,42 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         return $stub;
     }
 
+    protected function getLineCoverageForFileWithEval(): CodeCoverage
+    {
+        $filter = new Filter;
+        $filter->includeFile(TEST_FILES_PATH . 'source_with_eval.php');
+
+        $coverage = new CodeCoverage(
+            $this->setUpXdebugStubForFileWithEval(),
+            $filter
+        );
+
+        $coverage->start('FileWithEval', true);
+        $coverage->stop();
+
+        return $coverage;
+    }
+
+    protected function setUpXdebugStubForFileWithEval(): Driver
+    {
+        $stub = $this->createStub(Driver::class);
+
+        $stub->method('stop')
+            ->willReturn(RawCodeCoverageData::fromXdebugWithoutPathCoverage(
+                [
+                    TEST_FILES_PATH . 'source_with_eval.php' => [
+                        3 => 1,
+                        5 => 1,
+                    ],
+                    TEST_FILES_PATH . 'source_with_eval.php(5) : eval()\'d code' => [
+                        1 => 1,
+                    ],
+                ]
+            ));
+
+        return $stub;
+    }
+
     protected function getCoverageForClassWithAnonymousFunction(): CodeCoverage
     {
         $filter = new Filter;

--- a/tests/_files/source_with_eval.php
+++ b/tests/_files/source_with_eval.php
@@ -1,0 +1,5 @@
+<?php
+
+$normalResult = 1 + 1;
+
+$evalResult = eval('return 1+1;');

--- a/tests/tests/PhpTest.php
+++ b/tests/tests/PhpTest.php
@@ -31,4 +31,16 @@ final class PhpTest extends TestCase
 
         $this->assertEquals($coverage, $unserialized);
     }
+
+    public function testPHPSerialisationProducesValidCodeWhenOutputIncludesSingleQuote(): void
+    {
+        $coverage = $this->getLineCoverageForFileWithEval();
+
+        /* @noinspection UnusedFunctionResultInspection */
+        (new PHP)->process($coverage, self::$TEST_TMP_PATH . '/serialized.php');
+
+        $unserialized = require self::$TEST_TMP_PATH . '/serialized.php';
+
+        $this->assertEquals($coverage, $unserialized);
+    }
 }


### PR DESCRIPTION
Hello @sebastianbergmann 

This PR should fix #842 by using a nowdoc instead of a quote-delimited string meaning that the whole problem of escaping quotes disappears entirely.

Includes a test for the `eval()'d code` case that required the escaping in the first place to avoid any future regression.

The build is failing because of a Composer issue, I cannot see how that might be related to the changes in the PR