### PR TITLE
Fix method name appearing in signature

### DIFF
--- a/src/Report/Cobertura.php
+++ b/src/Report/Cobertura.php
@@ -149,6 +149,8 @@ final class Cobertura
                         continue;
                     }
 
+                    preg_match("/\((.*?)\)/", $method['signature'], $signature);
+
                     $linesValid   = $method['executableLines'];
                     $linesCovered = $method['executedLines'];
                     $lineRate     = $linesValid === 0 ? 0 : ($linesCovered / $linesValid);
@@ -160,7 +162,7 @@ final class Cobertura
                     $methodElement = $document->createElement('method');
 
                     $methodElement->setAttribute('name', $methodName);
-                    $methodElement->setAttribute('signature', $method['signature']);
+                    $methodElement->setAttribute('signature', $signature[1]);
                     $methodElement->setAttribute('line-rate', (string) $lineRate);
                     $methodElement->setAttribute('branch-rate', (string) $branchRate);
                     $methodElement->setAttribute('complexity', (string) $method['ccn']);

--- a/tests/_files/BankAccount-cobertura-line.xml
+++ b/tests/_files/BankAccount-cobertura-line.xml
@@ -9,12 +9,12 @@
       <classes>
         <class name="BankAccount" filename="BankAccount.php" line-rate="0.5" branch-rate="0" complexity="5">
           <methods>
-            <method name="getBalance" signature="getBalance()" line-rate="1" branch-rate="0" complexity="1">
+            <method name="getBalance" signature="" line-rate="1" branch-rate="0" complexity="1">
               <lines>
                 <line number="8" hits="2"/>
               </lines>
             </method>
-            <method name="setBalance" signature="setBalance($balance)" line-rate="0" branch-rate="0" complexity="2">
+            <method name="setBalance" signature="$balance" line-rate="0" branch-rate="0" complexity="2">
               <lines>
                 <line number="13" hits="0"/>
                 <line number="14" hits="0"/>
@@ -23,13 +23,13 @@
                 <line number="18" hits="0"/>
               </lines>
             </method>
-            <method name="depositMoney" signature="depositMoney($balance)" line-rate="1" branch-rate="0" complexity="1">
+            <method name="depositMoney" signature="$balance" line-rate="1" branch-rate="0" complexity="1">
               <lines>
                 <line number="22" hits="2"/>
                 <line number="24" hits="1"/>
               </lines>
             </method>
-            <method name="withdrawMoney" signature="withdrawMoney($balance)" line-rate="1" branch-rate="0" complexity="1">
+            <method name="withdrawMoney" signature="$balance" line-rate="1" branch-rate="0" complexity="1">
               <lines>
                 <line number="29" hits="2"/>
                 <line number="31" hits="1"/>

--- a/tests/_files/BankAccount-cobertura-path.xml
+++ b/tests/_files/BankAccount-cobertura-path.xml
@@ -9,12 +9,12 @@
       <classes>
         <class name="BankAccount" filename="BankAccount.php" line-rate="0.5" branch-rate="0.42857142857143" complexity="5">
           <methods>
-            <method name="getBalance" signature="getBalance()" line-rate="1" branch-rate="1" complexity="1">
+            <method name="getBalance" signature="" line-rate="1" branch-rate="1" complexity="1">
               <lines>
                 <line number="8" hits="2"/>
               </lines>
             </method>
-            <method name="setBalance" signature="setBalance($balance)" line-rate="0" branch-rate="0" complexity="2">
+            <method name="setBalance" signature="$balance" line-rate="0" branch-rate="0" complexity="2">
               <lines>
                 <line number="13" hits="0"/>
                 <line number="14" hits="0"/>
@@ -23,13 +23,13 @@
                 <line number="18" hits="0"/>
               </lines>
             </method>
-            <method name="depositMoney" signature="depositMoney($balance)" line-rate="1" branch-rate="1" complexity="1">
+            <method name="depositMoney" signature="$balance" line-rate="1" branch-rate="1" complexity="1">
               <lines>
                 <line number="22" hits="2"/>
                 <line number="24" hits="1"/>
               </lines>
             </method>
-            <method name="withdrawMoney" signature="withdrawMoney($balance)" line-rate="1" branch-rate="1" complexity="1">
+            <method name="withdrawMoney" signature="$balance" line-rate="1" branch-rate="1" complexity="1">
               <lines>
                 <line number="29" hits="2"/>
                 <line number="31" hits="1"/>

--- a/tests/_files/class-with-anonymous-function-cobertura.xml
+++ b/tests/_files/class-with-anonymous-function-cobertura.xml
@@ -9,7 +9,7 @@
       <classes>
         <class name="CoveredClassWithAnonymousFunctionInStaticMethod" filename="source_with_class_and_anonymous_function.php" line-rate="0.88888888888889" branch-rate="0" complexity="1">
           <methods>
-            <method name="runAnonymous" signature="runAnonymous()" line-rate="0.88888888888889" branch-rate="0" complexity="1">
+            <method name="runAnonymous" signature="" line-rate="0.88888888888889" branch-rate="0" complexity="1">
               <lines>
                 <line number="7" hits="1"/>
                 <line number="9" hits="1"/>

--- a/tests/_files/class-with-outside-function-cobertura.xml
+++ b/tests/_files/class-with-outside-function-cobertura.xml
@@ -9,7 +9,7 @@
       <classes>
         <class name="ClassInFileWithOutsideFunction" filename="source_with_class_and_outside_function.php" line-rate="1" branch-rate="0" complexity="1">
           <methods>
-            <method name="classMethod" signature="classMethod(): string" line-rate="1" branch-rate="0" complexity="1">
+            <method name="classMethod" signature="" line-rate="1" branch-rate="0" complexity="1">
               <lines>
                 <line number="6" hits="1"/>
               </lines>


### PR DESCRIPTION
In reference to #846

Parses out the method name so that only what is inside the brackets is kept.