### PR TITLE
Empty value for XDEBUG_MODE environment variable is not handled correctly

### DIFF
--- a/src/Driver/Xdebug3Driver.php
+++ b/src/Driver/Xdebug3Driver.php
@@ -56,7 +56,7 @@ final class Xdebug3Driver extends Driver
 
         $mode = getenv('XDEBUG_MODE');
 
-        if ($mode === false) {
+        if ($mode === false || $mode === '') {
             $mode = ini_get('xdebug.mode');
         }
 


### PR DESCRIPTION
| Q                   | A
| --------------------| ---------------
| PHPUnit version     | 9.5.8
| php-code-coverage| 9.1.4
| PHP version         | 8.0.5
| Xdebug version | 3.0.4
| Installation Method | Composer

#### Summary

If the `XDEBUG_MODE` environment variable is an empty string Xdebug uses its ini configuration.

#### Current behavior

php-code-coverage throws a `Xdebug3NotEnabledException`

#### How to reproduce

Set `XDEBUG_MODE` environment variable to an empty string.
Run `xdebug_info()`
The 'Enabled Features' section show the enabled modules according to the ini file
Run PHPunit with code coverage

#### Expected behavior

php-code-coverage uses ini when `XDEBUG_MODE` is empty.

#### Pull request

This PR applies the the expected behavior to php-code-coverage.