### PR TITLE
prevent uncovered classes from showing up in html coverage report

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -295,10 +295,6 @@ final class CodeCoverage
             throw new RuntimeException;
         }
 
-        $this->applyWhitelistFilter($data);
-        $this->applyIgnoredLinesFilter($data);
-        $this->initializeFilesThatAreSeenTheFirstTime($data);
-
         if (!$append) {
             return;
         }
@@ -315,6 +311,10 @@ final class CodeCoverage
         if (empty($data)) {
             return;
         }
+
+        $this->applyWhitelistFilter($data);
+        $this->applyIgnoredLinesFilter($data);
+        $this->initializeFilesThatAreSeenTheFirstTime($data);
 
         $size   = 'unknown';
         $status = -1;


### PR DESCRIPTION
When `@covers` annotation was applied to tests, some uncovered classes still ended up in final coverage report, `html` in my case. Apart from cluttering the report and messing up the code coverage caculation, it also slowed down report generation significantly, especially for html.

It boils down to this two lines of code. 
```
$this->initializeFilesThatAreSeenTheFirstTime
...
$this->applyCoversAnnotationFilter
```
`applyCoversAnnotationFilter` removes the uncovered files, however before that `initializeFilesThatAreSeenTheFirstTime` would have already added them to the output (unless that's intentional). In this commit I switched their orders. It is also slightly faster because now `applyIgnoredLinesFilter` has less work to do.

From what I read the change shouldn't have any other side effects. However the code is old, let me know if it breaks anything.

