### PR TITLE
#864 Uncovered files should be ignored unless requested

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -167,6 +167,8 @@ final class CodeCoverage
                 $this->processUncoveredFilesFromFilter();
             } elseif ($this->includeUncoveredFiles) {
                 $this->addUncoveredFilesFromFilter();
+            } else {
+                $this->data->removeFilesWithNoCoverage();
             }
         }
 

--- a/src/ProcessedCodeCoverageData.php
+++ b/src/ProcessedCodeCoverageData.php
@@ -132,6 +132,18 @@ final class ProcessedCodeCoverageData
         unset($this->lineCoverage[$oldFile], $this->functionCoverage[$oldFile]);
     }
 
+    public function removeFilesWithNoCoverage(): void
+    {
+        foreach ($this->lineCoverage as $file => $lines) {
+            foreach ($lines as $line) {
+                if (is_array($line) && !empty($line)) {
+                    continue 2;
+                }
+            }
+            unset($file);
+        }
+    }
+
     public function merge(self $newData): void
     {
         foreach ($newData->lineCoverage as $file => $lines) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1812,4 +1812,128 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $fileInfo->isDir() ? rmdir($pathname) : unlink($pathname);
         }
     }
+
+    protected function getCoverageForFilesWithUncoveredIncluded(): CodeCoverage
+    {
+        $data = $this->getLineCoverageXdebugDataForBankAccount();
+
+        $stub = $this->createStub(Driver::class);
+
+        $stub->method('stop')
+            ->will($this->onConsecutiveCalls(...$data));
+
+        $filter = new Filter;
+        $filter->includeFile(TEST_FILES_PATH . 'BankAccount.php');
+        $filter->includeFile(TEST_FILES_PATH . 'NamespacedBankAccount.php');
+
+        $coverage = new CodeCoverage($stub, $filter);
+        $coverage->includeUncoveredFiles();
+
+        $coverage->start(
+            new BankAccountTest('testBalanceIsInitiallyZero'),
+            true
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(6, 9)]
+        );
+
+        $coverage->start(
+            new BankAccountTest('testBalanceCannotBecomeNegative')
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(27, 32)]
+        );
+
+        $coverage->start(
+            new BankAccountTest('testBalanceCannotBecomeNegative2')
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(20, 25)]
+        );
+
+        $coverage->start(
+            new BankAccountTest('testDepositWithdrawMoney')
+        );
+
+        $coverage->stop(
+            true,
+            [
+                TEST_FILES_PATH . 'BankAccount.php' => array_merge(
+                    range(6, 9),
+                    range(20, 25),
+                    range(27, 32)
+                ),
+            ]
+        );
+
+        return $coverage;
+    }
+
+    protected function getCoverageForFilesWithUncoveredExcluded(): CodeCoverage
+    {
+        $data = $this->getLineCoverageXdebugDataForBankAccount();
+
+        $stub = $this->createStub(Driver::class);
+
+        $stub->method('stop')
+            ->will($this->onConsecutiveCalls(...$data));
+
+        $filter = new Filter;
+        $filter->includeFile(TEST_FILES_PATH . 'BankAccount.php');
+        $filter->includeFile(TEST_FILES_PATH . 'NamespacedBankAccount.php');
+
+        $coverage = new CodeCoverage($stub, $filter);
+        $coverage->excludeUncoveredFiles();
+
+        $coverage->start(
+            new BankAccountTest('testBalanceIsInitiallyZero'),
+            true
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(6, 9)]
+        );
+
+        $coverage->start(
+            new BankAccountTest('testBalanceCannotBecomeNegative')
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(27, 32)]
+        );
+
+        $coverage->start(
+            new BankAccountTest('testBalanceCannotBecomeNegative2')
+        );
+
+        $coverage->stop(
+            true,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(20, 25)]
+        );
+
+        $coverage->start(
+            new BankAccountTest('testDepositWithdrawMoney')
+        );
+
+        $coverage->stop(
+            true,
+            [
+                TEST_FILES_PATH . 'BankAccount.php' => array_merge(
+                    range(6, 9),
+                    range(20, 25),
+                    range(27, 32)
+                ),
+            ]
+        );
+
+        return $coverage;
+    }
 }

--- a/tests/_files/BankAccountWithUncovered-text-line.txt
+++ b/tests/_files/BankAccountWithUncovered-text-line.txt
@@ -1,0 +1,12 @@
+
+
+Code Coverage Report:   
+  %s
+                        
+ Summary:               
+  Classes:  0.00% (0/2) 
+  Methods: 37.50% (3/8) 
+  Lines:   26.32% (5/19)
+
+BankAccount
+  Methods:  75.00% ( 3/ 4)   Lines:  50.00% (  5/ 10)

--- a/tests/_files/BankAccountWithoutUncovered-text-line.txt
+++ b/tests/_files/BankAccountWithoutUncovered-text-line.txt
@@ -1,0 +1,12 @@
+
+
+Code Coverage Report:   
+  %s
+                        
+ Summary:               
+  Classes:  0.00% (0/1) 
+  Methods: 75.00% (3/4) 
+  Lines:   50.00% (5/10)
+
+BankAccount
+  Methods:  75.00% ( 3/ 4)   Lines:  50.00% (  5/ 10)

--- a/tests/tests/TextTest.php
+++ b/tests/tests/TextTest.php
@@ -77,4 +77,24 @@ final class TextTest extends TestCase
             str_replace(PHP_EOL, "\n", $text->process($this->getCoverageForClassWithAnonymousFunction()))
         );
     }
+
+    public function testUncoveredFilesAreIncludedWhenConfiguredTest(): void
+    {
+        $text = new Text(50, 90, false, false);
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccountWithUncovered-text-line.txt',
+            str_replace(PHP_EOL, "\n", $text->process($this->getCoverageForFilesWithUncoveredIncluded()))
+        );
+    }
+
+    public function testUncoveredFilesAreExcludedWhenConfiguredTest(): void
+    {
+        $text = new Text(50, 90, false, false);
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'BankAccountWithoutUncovered-text-line.txt',
+            str_replace(PHP_EOL, "\n", $text->process($this->getCoverageForFilesWithUncoveredExcluded()))
+        );
+    }
 }


### PR DESCRIPTION
_for version 9_

There are too many permutations of the various scenarios (`includeUncoveredFiles = true|false`, `processUncoveredFiles = true|false`, `@covers passing|failing` for the file, `@covers passing|failing` for an individual method, `@codeCoverageIgnore` annotations etc, multiplied by whether the file/method has been seen already or if this is the first time to sensibly try and disentangle the necessary code paths within `->append()`.

Therefore don't even try during the collection phase, just deal with it at report generation time instead.