### PR TITLE
Fix CI for branches that target master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: CI
 
+env:
+  COMPOSER_ROOT_VERSION: "10.x-dev"
+
 jobs:
   coding-guidelines:
     name: Coding Guidelines


### PR DESCRIPTION
Hello @sebastianbergmann 

The recursive dependency between PHPUnit and php-code-coverage means that Composer needs a bit of help resolving the versions in use. The `master` branch works because of the branch alias in [`composer.json`](https://github.com/sebastianbergmann/php-code-coverage/blob/master/composer.json#L66) but this isn't sufficient for building/testing a PR (e.g. #869)