### PR TITLE
XdebugFileDriver

### DIFF
--- a/src/Driver/XdebugFileDriver.php
+++ b/src/Driver/XdebugFileDriver.php
@@ -1,0 +1,45 @@
+<?php
+namespace SebastianBergmann\PHPCOV;
+
+use SebastianBergmann\CodeCoverage\Driver\Driver;
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
+
+final class XdebugFileDriver extends Driver
+{
+    public function __construct($fileName, $mapFrom = "", $mapTo = "")
+    {
+        $this->data = array();
+
+        foreach(json_decode(file_get_contents($fileName), true) as $key => $value) {
+            $this->data[str_replace($mapFrom, $mapTo, $key)] = $value;
+        }
+    }
+
+    public function canCollectBranchAndPathCoverage(): bool
+    {
+        return true;
+    }
+
+    public function canDetectDeadCode(): bool
+    {
+        return true;
+    }
+
+    public function start(): void
+    {
+    }
+
+    public function stop(): RawCodeCoverageData
+    {
+        if ($this->collectsBranchAndPathCoverage()) {
+            return RawCodeCoverageData::fromXdebugWithPathCoverage($this->data);
+        }
+
+        return RawCodeCoverageData::fromXdebugWithoutPathCoverage($this->data);
+    }
+
+    public function nameAndVersion(): string
+    {
+        return 'Xdebug file driver';
+    }
+}


### PR DESCRIPTION
Like suggested in https://github.com/sebastianbergmann/phpcov/pull/111

> Thank you for your contribution. I appreciate the time you invested in preparing this pull request. However, I have decided not to merge it because I do not want code coverage driver specific code in this tool.
> 
> I think it would make sense to add functionality in `php-code-coverage` to serialize that component's object graph to JSON (and vice versa).

First, thanks for you quick response. That's exceptional!

I've tried to implement this in `class CodeCoverage` without using the drivers module but `CodeCoverage` depends too much on a loaded driver (it's even an argument for the constructor).

Is this PR sufficient or would you like to have an implementation (`CodeCoverage::fromXdebugJSON()` and `$codeCoverage->toXdebugJSON()`) as part of this PR (which will use the `XdebugFileDriver`)?