### PR TITLE
Remove useless code

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -167,8 +167,6 @@ final class CodeCoverage
                 $this->processUncoveredFilesFromFilter();
             } elseif ($this->includeUncoveredFiles) {
                 $this->addUncoveredFilesFromFilter();
-            } else {
-                $this->data->removeFilesWithNoCoverage();
             }
         }
 

--- a/src/ProcessedCodeCoverageData.php
+++ b/src/ProcessedCodeCoverageData.php
@@ -132,18 +132,6 @@ final class ProcessedCodeCoverageData
         unset($this->lineCoverage[$oldFile], $this->functionCoverage[$oldFile]);
     }
 
-    public function removeFilesWithNoCoverage(): void
-    {
-        foreach ($this->lineCoverage as $file => $lines) {
-            foreach ($lines as $line) {
-                if (is_array($line) && !empty($line)) {
-                    continue 2;
-                }
-            }
-            unset($file);
-        }
-    }
-
     public function merge(self $newData): void
     {
         foreach ($newData->lineCoverage as $file => $lines) {


### PR DESCRIPTION
See https://github.com/sebastianbergmann/php-code-coverage/pull/868#discussion_r800496605

The method does nothing: `unset($file);` has no effect on anything, it's just an unused local array key