### PR TITLE
Line coverage stubs: be consistent with actual xDebug/PCOV output

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,30 +50,46 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
+                    9  => -2,
                     13 => 1,
+                    14 => -1,
+                    15 => -1,
                     16 => 1,
+                    18 => -1,
                     29 => 1,
+                    31 => -1,
+                    32 => -2,
                 ],
             ]),
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
+                    9  => -2,
                     13 => 1,
+                    14 => -1,
+                    15 => -1,
                     16 => 1,
+                    18 => -1,
                     22 => 1,
+                    24 => -1,
+                    25 => -2,
                 ],
             ]),
             RawCodeCoverageData::fromXdebugWithoutPathCoverage([
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     8  => 1,
+                    9  => -2,
                     13 => 1,
                     14 => 1,
                     15 => 1,
+                    16 => -1,
                     18 => 1,
                     22 => 1,
                     24 => 1,
+                    25 => -2,
                     29 => 1,
                     31 => 1,
+                    32 => -2,
                 ],
             ]),
         ];
@@ -276,9 +292,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     'lines' => [
                         8  => 1,
+                        9  => -2,
                         13 => 1,
+                        14 => -1,
+                        15 => -1,
                         16 => 1,
+                        18 => -1,
                         29 => 1,
+                        31 => -1,
+                        32 => -2,
                     ],
                     'functions' => [
                         'BankAccount->depositMoney' => [
@@ -457,9 +479,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     'lines' => [
                         8  => 1,
+                        9  => -2,
                         13 => 1,
+                        14 => -1,
+                        15 => -1,
                         16 => 1,
+                        18 => -1,
                         22 => 1,
+                        24 => -1,
+                        25 => -2,
                     ],
                     'functions' => [
                         'BankAccount->depositMoney' => [
@@ -638,14 +666,18 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                 TEST_FILES_PATH . 'BankAccount.php' => [
                     'lines' => [
                         8  => 1,
+                        9  => -2,
                         13 => 1,
                         14 => 1,
                         15 => 1,
+                        16 => -1,
                         18 => 1,
                         22 => 1,
                         24 => 1,
+                        25 => -2,
                         29 => 1,
                         31 => 1,
+                        32 => -2,
                     ],
                     'functions' => [
                         'BankAccount->depositMoney' => [


### PR DESCRIPTION
Found this inconsistency while investigating https://github.com/sebastianbergmann/php-code-coverage/issues/889

I manually checked both `Xdebug3Driver` and `PcovDriver` outputs and they differ a bit from what's coded in `TestCase`.

Most of the differences are negligible and have no impact on the purpose of the involved tests, they all still pass, but the diff addressed in this PR can sneak bugs in the future if not merged, especially while merging multiple CC reports.