### PR TITLE
Synchronize column ordering between Html\Renderers

### DIFF
--- a/src/Report/Html/Renderer/Template/file.html.dist
+++ b/src/Report/Html/Renderer/Template/file.html.dist
@@ -33,9 +33,9 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>

--- a/src/Report/Html/Renderer/Template/file_branch.html.dist
+++ b/src/Report/Html/Renderer/Template/file_branch.html.dist
@@ -33,11 +33,11 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>

--- a/src/Report/Html/Renderer/Template/file_item.html.dist
+++ b/src/Report/Html/Renderer/Template/file_item.html.dist
@@ -1,14 +1,14 @@
       <tr>
        <td class="{{classes_level}}">{{name}}</td>
-       <td class="{{classes_level}} big">{{classes_bar}}</td>
-       <td class="{{classes_level}} small"><div align="right">{{classes_tested_percent}}</div></td>
-       <td class="{{classes_level}} small"><div align="right">{{classes_number}}</div></td>
+       <td class="{{lines_level}} big">{{lines_bar}}</td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
        <td class="{{methods_level}} big">{{methods_bar}}</td>
        <td class="{{methods_level}} small"><div align="right">{{methods_tested_percent}}</div></td>
        <td class="{{methods_level}} small"><div align="right">{{methods_number}}</div></td>
        <td class="{{methods_level}} small">{{crap}}</td>
-       <td class="{{lines_level}} big">{{lines_bar}}</td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
+       <td class="{{classes_level}} big">{{classes_bar}}</td>
+       <td class="{{classes_level}} small"><div align="right">{{classes_tested_percent}}</div></td>
+       <td class="{{classes_level}} small"><div align="right">{{classes_number}}</div></td>
       </tr>
 

--- a/src/Report/Html/Renderer/Template/file_item_branch.html.dist
+++ b/src/Report/Html/Renderer/Template/file_item_branch.html.dist
@@ -1,20 +1,20 @@
       <tr>
        <td class="{{classes_level}}">{{name}}</td>
-       <td class="{{classes_level}} big">{{classes_bar}}</td>
-       <td class="{{classes_level}} small"><div align="right">{{classes_tested_percent}}</div></td>
-       <td class="{{classes_level}} small"><div align="right">{{classes_number}}</div></td>
+       <td class="{{lines_level}} big">{{lines_bar}}</td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
+       <td class="{{branches_level}} big">{{branches_bar}}</td>
+       <td class="{{branches_level}} small"><div align="right">{{branches_executed_percent}}</div></td>
+       <td class="{{branches_level}} small"><div align="right">{{branches_number}}</div></td>
+       <td class="{{paths_level}} big">{{paths_bar}}</td>
+       <td class="{{paths_level}} small"><div align="right">{{paths_executed_percent}}</div></td>
+       <td class="{{paths_level}} small"><div align="right">{{paths_number}}</div></td>
        <td class="{{methods_level}} big">{{methods_bar}}</td>
        <td class="{{methods_level}} small"><div align="right">{{methods_tested_percent}}</div></td>
        <td class="{{methods_level}} small"><div align="right">{{methods_number}}</div></td>
        <td class="{{methods_level}} small">{{crap}}</td>
-       <td class="{{paths_level}} big">{{paths_bar}}</td>
-       <td class="{{paths_level}} small"><div align="right">{{paths_executed_percent}}</div></td>
-       <td class="{{paths_level}} small"><div align="right">{{paths_number}}</div></td>
-       <td class="{{branches_level}} big">{{branches_bar}}</td>
-       <td class="{{branches_level}} small"><div align="right">{{branches_executed_percent}}</div></td>
-       <td class="{{branches_level}} small"><div align="right">{{branches_number}}</div></td>
-       <td class="{{lines_level}} big">{{lines_bar}}</td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
+       <td class="{{classes_level}} big">{{classes_bar}}</td>
+       <td class="{{classes_level}} small"><div align="right">{{classes_tested_percent}}</div></td>
+       <td class="{{classes_level}} small"><div align="right">{{classes_number}}</div></td>
       </tr>
 

--- a/src/Report/Html/Renderer/Template/method_item.html.dist
+++ b/src/Report/Html/Renderer/Template/method_item.html.dist
@@ -1,11 +1,12 @@
       <tr>
-       <td class="{{methods_level}}" colspan="4">{{name}}</td>
+       <td class="{{methods_level}}">{{name}}</td>
+       <td class="{{lines_level}} big">{{lines_bar}}</td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
        <td class="{{methods_level}} big">{{methods_bar}}</td>
        <td class="{{methods_level}} small"><div align="right">{{methods_tested_percent}}</div></td>
        <td class="{{methods_level}} small"><div align="right">{{methods_number}}</div></td>
        <td class="{{methods_level}} small">{{crap}}</td>
-       <td class="{{lines_level}} big">{{lines_bar}}</td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
+       <td class="{{methods_level}}" colspan="3"></td>
       </tr>
 

--- a/src/Report/Html/Renderer/Template/method_item_branch.html.dist
+++ b/src/Report/Html/Renderer/Template/method_item_branch.html.dist
@@ -1,17 +1,18 @@
       <tr>
-       <td class="{{methods_level}}" colspan="4">{{name}}</td>
+       <td class="{{methods_level}}">{{name}}</td>
+       <td class="{{lines_level}} big">{{lines_bar}}</td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
+       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
+       <td class="{{branches_level}} big">{{branches_bar}}</td>
+       <td class="{{branches_level}} small"><div align="right">{{branches_executed_percent}}</div></td>
+       <td class="{{branches_level}} small"><div align="right">{{branches_number}}</div></td>
+       <td class="{{paths_level}} big">{{paths_bar}}</td>
+       <td class="{{paths_level}} small"><div align="right">{{paths_executed_percent}}</div></td>
+       <td class="{{paths_level}} small"><div align="right">{{paths_number}}</div></td>
        <td class="{{methods_level}} big">{{methods_bar}}</td>
        <td class="{{methods_level}} small"><div align="right">{{methods_tested_percent}}</div></td>
        <td class="{{methods_level}} small"><div align="right">{{methods_number}}</div></td>
        <td class="{{methods_level}} small">{{crap}}</td>
-       <td class="{{paths_level}} big">{{paths_bar}}</td>
-       <td class="{{paths_level}} small"><div align="right">{{paths_executed_percent}}</div></td>
-       <td class="{{paths_level}} small"><div align="right">{{paths_number}}</div></td>
-       <td class="{{branches_level}} big">{{branches_bar}}</td>
-       <td class="{{branches_level}} small"><div align="right">{{branches_executed_percent}}</div></td>
-       <td class="{{branches_level}} small"><div align="right">{{branches_number}}</div></td>
-       <td class="{{lines_level}} big">{{lines_bar}}</td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
-       <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>
+       <td class="{{methods_level}}" colspan="3"></td>
       </tr>
 

--- a/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
+++ b/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
@@ -35,22 +35,22 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="danger">Total</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div align="right">55.56%</div></td>
+       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -60,18 +60,6 @@
        <td class="warning small"><div align="right">75.00%</div></td>
        <td class="warning small"><div align="right">3&nbsp;/&nbsp;4</div></td>
        <td class="warning small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div align="right">55.56%</div></td>
-       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger">BankAccount</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -80,6 +68,18 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger">BankAccount</td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div align="right">55.56%</div></td>
+       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -89,18 +89,26 @@
        <td class="warning small"><div align="right">75.00%</div></td>
        <td class="warning small"><div align="right">3&nbsp;/&nbsp;4</div></td>
        <td class="warning small">7.19</td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div align="right">55.56%</div></td>
-       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -110,18 +118,19 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="danger" colspan="4">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
+       <td class="danger">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -131,18 +140,19 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -152,6 +162,11 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
+       <td class="success" colspan="3"></td>
+      </tr>
+
+      <tr>
+       <td class="success">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -160,10 +175,6 @@
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
-      </tr>
-
-      <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -173,14 +184,7 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
 

--- a/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
+++ b/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
@@ -35,17 +35,22 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -55,25 +60,21 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
       </tr>
 
       <tr>
-       <td class="" colspan="4"><a href="#28"><abbr title="baz()">baz</abbr></a></td>
+       <td class=""><a href="#28"><abbr title="baz()">baz</abbr></a></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">1</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="" colspan="3"></td>
       </tr>
 
       <tr>
@@ -91,14 +92,15 @@
       </tr>
 
       <tr>
-       <td class="" colspan="4">&nbsp;<a href="#13"><abbr title="bar()">bar</abbr></a></td>
+       <td class="">&nbsp;<a href="#13"><abbr title="bar()">bar</abbr></a></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">1</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="" colspan="3"></td>
       </tr>
 
       <tr>
@@ -116,14 +118,15 @@
       </tr>
 
       <tr>
-       <td class="" colspan="4">&nbsp;<a href="#23"><abbr title="foo()">foo</abbr></a></td>
+       <td class="">&nbsp;<a href="#23"><abbr title="foo()">foo</abbr></a></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">1</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="" colspan="3"></td>
       </tr>
 
 

--- a/tests/_files/Report/HTML/PHP80AndBelow/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.html
@@ -35,9 +35,9 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
@@ -50,7 +50,7 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -67,7 +67,7 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
@@ -79,7 +79,7 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -96,11 +96,19 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#5"><abbr title="runAnonymous()">runAnonymous</abbr></a></td>
+       <td class="success">&nbsp;<a href="#5"><abbr title="runAnonymous()">runAnonymous</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -110,14 +118,7 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
 

--- a/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
@@ -35,19 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -57,6 +78,29 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -65,26 +109,6 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger" colspan="4"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -94,30 +118,7 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
@@ -128,13 +129,13 @@
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">0</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>

--- a/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
@@ -35,19 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -57,6 +78,29 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -65,26 +109,6 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger" colspan="4"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -94,30 +118,7 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
@@ -128,13 +129,13 @@
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">0</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>

--- a/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
@@ -35,19 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -57,6 +78,29 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -65,26 +109,6 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger" colspan="4"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -94,30 +118,7 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
@@ -128,13 +129,13 @@
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">0</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>

--- a/tests/_files/Report/HTML/PHP81AndUp/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.html
@@ -35,9 +35,9 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
@@ -50,7 +50,7 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -67,7 +67,7 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
@@ -79,7 +79,7 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -96,11 +96,19 @@
        </div>
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#5"><abbr title="runAnonymous()">runAnonymous</abbr></a></td>
+       <td class="success">&nbsp;<a href="#5"><abbr title="runAnonymous()">runAnonymous</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -110,14 +118,7 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">5&nbsp;/&nbsp;5</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
 

--- a/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
@@ -35,19 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -57,6 +78,29 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -65,26 +109,6 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger" colspan="4"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -94,30 +118,7 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
@@ -128,13 +129,13 @@
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">0</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>

--- a/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
@@ -35,19 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -57,6 +78,29 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -65,26 +109,6 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger" colspan="4"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -94,30 +118,7 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
@@ -128,13 +129,13 @@
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">0</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>

--- a/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
@@ -35,19 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="">Total</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -57,6 +78,29 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -65,26 +109,6 @@
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger" colspan="4"><a href="#12"><abbr title="&amp;foo($bar)">foo</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -94,30 +118,7 @@
        <td class="danger small"><div align="right">0.00%</div></td>
        <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
        <td class="danger small">6</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;2</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
@@ -128,13 +129,13 @@
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
+       <td class=" big"></td>
+       <td class=" small"><div align="right">n/a</div></td>
+       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" small">0</td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
-       <td class=" big"></td>
-       <td class=" small"><div align="right">n/a</div></td>
-       <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>
        <td class=" big"></td>
        <td class=" small"><div align="right">n/a</div></td>
        <td class=" small"><div align="right">0&nbsp;/&nbsp;0</div></td>

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php.html
@@ -35,24 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="danger">Total</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div align="right">55.56%</div></td>
+       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
+           <span class="sr-only">42.86% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">42.86%</div></td>
+       <td class="danger small"><div align="right">3&nbsp;/&nbsp;7</div></td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
+           <span class="sr-only">60.00% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div align="right">60.00%</div></td>
+       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -62,14 +78,26 @@
        <td class="warning small"><div align="right">75.00%</div></td>
        <td class="warning small"><div align="right">3&nbsp;/&nbsp;4</div></td>
        <td class="warning small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
-           <span class="sr-only">60.00% covered (warning)</span>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div align="right">60.00%</div></td>
-       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger">BankAccount</td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div align="right">55.56%</div></td>
+       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
            <span class="sr-only">42.86% covered (danger)</span>
@@ -79,25 +107,13 @@
        <td class="danger small"><div align="right">42.86%</div></td>
        <td class="danger small"><div align="right">3&nbsp;/&nbsp;7</div></td>
        <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
+           <span class="sr-only">60.00% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div align="right">55.56%</div></td>
-       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger">BankAccount</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div align="right">60.00%</div></td>
+       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -107,34 +123,42 @@
        <td class="warning small"><div align="right">75.00%</div></td>
        <td class="warning small"><div align="right">3&nbsp;/&nbsp;4</div></td>
        <td class="warning small">6.60</td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
-           <span class="sr-only">60.00% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div align="right">60.00%</div></td>
-       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
        <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
-           <span class="sr-only">42.86% covered (danger)</span>
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div align="right">42.86%</div></td>
-       <td class="danger small"><div align="right">3&nbsp;/&nbsp;7</div></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div align="right">55.56%</div></td>
-       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -144,34 +168,11 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="danger" colspan="4">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
+       <td class="danger">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -179,8 +180,15 @@
        </div>
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
-       <td class="danger small">6</td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -196,19 +204,37 @@
        </div>
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="danger small">6</td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -218,22 +244,11 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
+      </tr>
+
+      <tr>
+       <td class="success">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -242,10 +257,22 @@
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
-      </tr>
-
-      <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -255,30 +282,7 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
 

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_branch.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_branch.html
@@ -35,24 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="danger">Total</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div align="right">55.56%</div></td>
+       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
+           <span class="sr-only">42.86% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">42.86%</div></td>
+       <td class="danger small"><div align="right">3&nbsp;/&nbsp;7</div></td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
+           <span class="sr-only">60.00% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div align="right">60.00%</div></td>
+       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -62,14 +78,26 @@
        <td class="warning small"><div align="right">75.00%</div></td>
        <td class="warning small"><div align="right">3&nbsp;/&nbsp;4</div></td>
        <td class="warning small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
-           <span class="sr-only">60.00% covered (warning)</span>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div align="right">60.00%</div></td>
-       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger">BankAccount</td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div align="right">55.56%</div></td>
+       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
            <span class="sr-only">42.86% covered (danger)</span>
@@ -79,25 +107,13 @@
        <td class="danger small"><div align="right">42.86%</div></td>
        <td class="danger small"><div align="right">3&nbsp;/&nbsp;7</div></td>
        <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
+           <span class="sr-only">60.00% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div align="right">55.56%</div></td>
-       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger">BankAccount</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div align="right">60.00%</div></td>
+       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -107,34 +123,42 @@
        <td class="warning small"><div align="right">75.00%</div></td>
        <td class="warning small"><div align="right">3&nbsp;/&nbsp;4</div></td>
        <td class="warning small">6.60</td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
-           <span class="sr-only">60.00% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div align="right">60.00%</div></td>
-       <td class="warning small"><div align="right">3&nbsp;/&nbsp;5</div></td>
        <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
-           <span class="sr-only">42.86% covered (danger)</span>
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div align="right">42.86%</div></td>
-       <td class="danger small"><div align="right">3&nbsp;/&nbsp;7</div></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div align="right">55.56%</div></td>
-       <td class="warning small"><div align="right">5&nbsp;/&nbsp;9</div></td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -144,34 +168,11 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="danger" colspan="4">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
+       <td class="danger">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -179,8 +180,15 @@
        </div>
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
-       <td class="danger small">6</td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div align="right">0.00%</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -196,19 +204,37 @@
        </div>
 </td>
        <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div align="right">0.00%</div></td>
-       <td class="danger small"><div align="right">0&nbsp;/&nbsp;4</div></td>
+       <td class="danger small"><div align="right">0&nbsp;/&nbsp;1</div></td>
+       <td class="danger small">6</td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -218,22 +244,11 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
+      </tr>
+
+      <tr>
+       <td class="success">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -242,10 +257,22 @@
 </td>
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
-      </tr>
-
-      <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div align="right">100.00%</div></td>
+       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -255,30 +282,7 @@
        <td class="success small"><div align="right">100.00%</div></td>
        <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div align="right">100.00%</div></td>
-       <td class="success small"><div align="right">2&nbsp;/&nbsp;2</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
 

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_path.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_path.html
@@ -35,24 +35,40 @@
       </tr>
       <tr>
        <td>&nbsp;</td>
-       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
-       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
-       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
        <td colspan="3"><div align="center"><strong>Lines</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Branches</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Paths</strong></div></td>
+       <td colspan="4"><div align="center"><strong>Functions and Methods</strong></div></td>
+       <td colspan="3"><div align="center"><strong>Classes and Traits</strong></div></td>
       </tr>
      </thead>
      <tbody>
       <tr>
        <td class="danger">Total</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div %s>0.00%</div></td>
-       <td class="danger small"><div %s>0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div %s>55.56%</div></td>
+       <td class="warning small"><div %s>5&nbsp;/&nbsp;9</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
+           <span class="sr-only">42.86% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div %s>42.86%</div></td>
+       <td class="danger small"><div %s>3&nbsp;/&nbsp;7</div></td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
+           <span class="sr-only">60.00% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div %s>60.00%</div></td>
+       <td class="warning small"><div %s>3&nbsp;/&nbsp;5</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -62,14 +78,26 @@
        <td class="warning small"><div %s>75.00%</div></td>
        <td class="warning small"><div %s>3&nbsp;/&nbsp;4</div></td>
        <td class="warning small"><abbr title="Change Risk Anti-Patterns (CRAP) Index">CRAP</abbr></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
-           <span class="sr-only">60.00% covered (warning)</span>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div %s>60.00%</div></td>
-       <td class="warning small"><div %s>3&nbsp;/&nbsp;5</div></td>
+       <td class="danger small"><div %s>0.00%</div></td>
+       <td class="danger small"><div %s>0&nbsp;/&nbsp;1</div></td>
+      </tr>
+
+      <tr>
+       <td class="danger">BankAccount</td>
+       <td class="warning big">       <div class="progress">
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
+           <span class="sr-only">55.56% covered (warning)</span>
+         </div>
+       </div>
+</td>
+       <td class="warning small"><div %s>55.56%</div></td>
+       <td class="warning small"><div %s>5&nbsp;/&nbsp;9</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
            <span class="sr-only">42.86% covered (danger)</span>
@@ -79,25 +107,13 @@
        <td class="danger small"><div %s>42.86%</div></td>
        <td class="danger small"><div %s>3&nbsp;/&nbsp;7</div></td>
        <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
+         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
+           <span class="sr-only">60.00% covered (warning)</span>
          </div>
        </div>
 </td>
-       <td class="warning small"><div %s>55.56%</div></td>
-       <td class="warning small"><div %s>5&nbsp;/&nbsp;9</div></td>
-      </tr>
-
-      <tr>
-       <td class="danger">BankAccount</td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div %s>0.00%</div></td>
-       <td class="danger small"><div %s>0&nbsp;/&nbsp;1</div></td>
+       <td class="warning small"><div %s>60.00%</div></td>
+       <td class="warning small"><div %s>3&nbsp;/&nbsp;5</div></td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="75.00" aria-valuemin="0" aria-valuemax="100" style="width: 75.00%">
            <span class="sr-only">75.00% covered (warning)</span>
@@ -107,34 +123,42 @@
        <td class="warning small"><div %s>75.00%</div></td>
        <td class="warning small"><div %s>3&nbsp;/&nbsp;4</div></td>
        <td class="warning small">6.60</td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="60.00" aria-valuemin="0" aria-valuemax="100" style="width: 60.00%">
-           <span class="sr-only">60.00% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div %s>60.00%</div></td>
-       <td class="warning small"><div %s>3&nbsp;/&nbsp;5</div></td>
        <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="42.86" aria-valuemin="0" aria-valuemax="100" style="width: 42.86%">
-           <span class="sr-only">42.86% covered (danger)</span>
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
          </div>
        </div>
 </td>
-       <td class="danger small"><div %s>42.86%</div></td>
-       <td class="danger small"><div %s>3&nbsp;/&nbsp;7</div></td>
-       <td class="warning big">       <div class="progress">
-         <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
-           <span class="sr-only">55.56% covered (warning)</span>
-         </div>
-       </div>
-</td>
-       <td class="warning small"><div %s>55.56%</div></td>
-       <td class="warning small"><div %s>5&nbsp;/&nbsp;9</div></td>
+       <td class="danger small"><div %s>0.00%</div></td>
+       <td class="danger small"><div %s>0&nbsp;/&nbsp;1</div></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success">&nbsp;<a href="#6"><abbr title="getBalance()">getBalance</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -144,34 +168,11 @@
        <td class="success small"><div %s>100.00%</div></td>
        <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="danger" colspan="4">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
+       <td class="danger">&nbsp;<a href="#11"><abbr title="setBalance($balance)">setBalance</abbr></a></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -179,8 +180,15 @@
        </div>
 </td>
        <td class="danger small"><div %s>0.00%</div></td>
-       <td class="danger small"><div %s>0&nbsp;/&nbsp;1</div></td>
-       <td class="danger small">6</td>
+       <td class="danger small"><div %s>0&nbsp;/&nbsp;4</div></td>
+       <td class="danger big">       <div class="progress">
+         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
+           <span class="sr-only">0.00% covered (danger)</span>
+         </div>
+       </div>
+</td>
+       <td class="danger small"><div %s>0.00%</div></td>
+       <td class="danger small"><div %s>0&nbsp;/&nbsp;4</div></td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>
@@ -196,19 +204,37 @@
        </div>
 </td>
        <td class="danger small"><div %s>0.00%</div></td>
-       <td class="danger small"><div %s>0&nbsp;/&nbsp;4</div></td>
-       <td class="danger big">       <div class="progress">
-         <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
-           <span class="sr-only">0.00% covered (danger)</span>
-         </div>
-       </div>
-</td>
-       <td class="danger small"><div %s>0.00%</div></td>
-       <td class="danger small"><div %s>0&nbsp;/&nbsp;4</div></td>
+       <td class="danger small"><div %s>0&nbsp;/&nbsp;1</div></td>
+       <td class="danger small">6</td>
+       <td class="danger" colspan="3"></td>
       </tr>
 
       <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success">&nbsp;<a href="#20"><abbr title="depositMoney($balance)">depositMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>2&nbsp;/&nbsp;2</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -218,22 +244,11 @@
        <td class="success small"><div %s>100.00%</div></td>
        <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
+       <td class="success" colspan="3"></td>
+      </tr>
+
+      <tr>
+       <td class="success">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -242,10 +257,22 @@
 </td>
        <td class="success small"><div %s>100.00%</div></td>
        <td class="success small"><div %s>2&nbsp;/&nbsp;2</div></td>
-      </tr>
-
-      <tr>
-       <td class="success" colspan="4">&nbsp;<a href="#27"><abbr title="withdrawMoney($balance)">withdrawMoney</abbr></a></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
+       <td class="success big">       <div class="progress">
+         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
+           <span class="sr-only">100.00% covered (success)</span>
+         </div>
+       </div>
+</td>
+       <td class="success small"><div %s>100.00%</div></td>
+       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>
@@ -255,30 +282,7 @@
        <td class="success small"><div %s>100.00%</div></td>
        <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
        <td class="success small">1</td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>1&nbsp;/&nbsp;1</div></td>
-       <td class="success big">       <div class="progress">
-         <div class="progress-bar bg-success" role="progressbar" %s style="width: 100.00%">
-           <span class="sr-only">100.00% covered (success)</span>
-         </div>
-       </div>
-</td>
-       <td class="success small"><div %s>100.00%</div></td>
-       <td class="success small"><div %s>2&nbsp;/&nbsp;2</div></td>
+       <td class="success" colspan="3"></td>
       </tr>
 
 


### PR DESCRIPTION
Fixes #827.

The column ordering was reversed in the File renderer compared to the
Directory renderer. This made it a bit confusing when jumping between
directory and file reports.

The File renderer now uses the same column ordering as the Directory
renderer.

Example File report summary from v9.2.11:
![image](https://user-images.githubusercontent.com/846186/154970962-85747aee-6997-4ac3-b8c7-c739829f6da2.png)

Example File report summary from this PR:
![image](https://user-images.githubusercontent.com/846186/154971026-d32d68d0-8c30-473e-ae86-94013039177e.png)
