### PR TITLE
Add interface to specify custom.css file for HTML report

### DIFF
--- a/src/Report/Html/Facade.php
+++ b/src/Report/Html/Facade.php
@@ -41,7 +41,12 @@ final class Facade
      */
     private $highLowerBound;
 
-    public function __construct(int $lowUpperBound = 50, int $highLowerBound = 90, string $generator = '')
+    /**
+     * @var ?string
+     */
+    private $customCssFile;
+
+    public function __construct(int $lowUpperBound = 50, int $highLowerBound = 90, string $generator = '', ?string $customCssFile = null)
     {
         if ($lowUpperBound > $highLowerBound) {
             throw new InvalidArgumentException(
@@ -52,6 +57,7 @@ final class Facade
         $this->generator      = $generator;
         $this->highLowerBound = $highLowerBound;
         $this->lowUpperBound  = $lowUpperBound;
+        $this->customCssFile  = $customCssFile;
         $this->templatePath   = __DIR__ . '/Renderer/Template/';
     }
 
@@ -118,7 +124,7 @@ final class Facade
         copy($this->templatePath . 'css/bootstrap.min.css', $dir . 'bootstrap.min.css');
         copy($this->templatePath . 'css/nv.d3.min.css', $dir . 'nv.d3.min.css');
         copy($this->templatePath . 'css/style.css', $dir . 'style.css');
-        copy($this->templatePath . 'css/custom.css', $dir . 'custom.css');
+        copy($this->customCssFile ?? $this->templatePath . 'css/custom.css', $dir . 'custom.css');
         copy($this->templatePath . 'css/octicons.css', $dir . 'octicons.css');
 
         $dir = $this->directory($target . '_icons');


### PR DESCRIPTION
Related to #556.

It would help to make the custom CSS feature more accessible by making
the file a configuration option, e.g. in phpunit:

    <coverage>
        <report>
            <html customCssFile="path/to/custom.css" />
        </report>
    </coverage>

The `$customCssFile` argument is added to the Html\Facade interface as
a prerequisite to any changes to phpunit configuration options. If not
null, it copies this file to the custom.css destination instead of the
empty custom.css stub file.

-----------------------

A couple logistical notes:
1. There wasn't an obvious way to add a good test for this feature. If there's something specific you'd like to see tested, I'm more than happy to add it.
2. If you're on board with this plan, I can also put together a PR in phpunit to add the configuration option. Is there any protocol for adding features to phpunit that depend on a specific version of php-code-coverage?

Thanks for your time!