### PR TITLE
Executable lines: fix empty constructor and match expression regressions

### DIFF
--- a/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
@@ -16,11 +16,13 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\MatchArm;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Case_;
@@ -160,6 +162,22 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             return $lines;
         }
 
+        if ($node instanceof Match_) {
+            return [$node->cond->getStartLine()];
+        }
+
+        if ($node instanceof MatchArm) {
+            return [$node->body->getStartLine()];
+        }
+
+        if ($node instanceof Expression && (
+            $node->expr instanceof Cast ||
+            $node->expr instanceof Match_ ||
+            $node->expr instanceof MethodCall
+        )) {
+            return [];
+        }
+
         return [$node->getStartLine()];
     }
 
@@ -187,6 +205,8 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
                $node instanceof Foreach_ ||
                $node instanceof Goto_ ||
                $node instanceof If_ ||
+               $node instanceof Match_ ||
+               $node instanceof MatchArm ||
                $node instanceof MethodCall ||
                $node instanceof NullsafePropertyFetch ||
                $node instanceof PropertyFetch ||

--- a/tests/_files/source_with_empty_constructor.php
+++ b/tests/_files/source_with_empty_constructor.php
@@ -1,0 +1,32 @@
+<?php
+
+class Foo
+{
+    public 
+        function 
+            __construct
+    (
+        public
+        $var
+        =
+        1
+    )
+    {
+        
+    }
+}
+
+class Bar
+{
+    public 
+        function 
+            __construct
+    (
+        $var
+        =
+        1
+    )
+    {
+        $var = 1;
+    }
+}

--- a/tests/_files/source_with_heavy_indentation.php
+++ b/tests/_files/source_with_heavy_indentation.php
@@ -155,9 +155,6 @@ final class BarS
                 )
             ;
 
-            $var[]
-            ;
-
             (string)
             $var
             ;

--- a/tests/_files/source_with_match_expression.php
+++ b/tests/_files/source_with_match_expression.php
@@ -1,0 +1,30 @@
+<?php
+
+class Foo
+{
+    public
+        function
+            __construct(
+                string
+                $bar
+    )
+    {
+        match
+        (
+            $bar
+        )
+        {
+            'a',
+            'b'
+            =>
+            1
+        ,
+            // Some comments
+            default
+            =>
+            throw new Exception()
+        ,
+        }
+        ;
+    }
+}

--- a/tests/tests/Data/RawCodeCoverageDataTest.php
+++ b/tests/tests/Data/RawCodeCoverageDataTest.php
@@ -377,6 +377,21 @@ final class RawCodeCoverageDataTest extends TestCase
         );
     }
 
+    public function testEmtpyConstructorIsMarkedAsExevutable(): void
+    {
+        $file = TEST_FILES_PATH . 'source_with_empty_constructor.php';
+
+        $this->assertEquals(
+            [
+                5,
+                6,
+                7,
+                30,
+            ],
+            array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
+        );
+    }
+
     public function testCoverageForFileWithInlineAnnotations(): void
     {
         $filename = TEST_FILES_PATH . 'source_with_oneline_annotations.php';

--- a/tests/tests/Data/RawCodeCoverageDataTest.php
+++ b/tests/tests/Data/RawCodeCoverageDataTest.php
@@ -366,18 +366,15 @@ final class RawCodeCoverageDataTest extends TestCase
                 135,
                 139,
                 143,
-                147,
                 149,
                 153,
-                158,
-                161,
-                162,
+                159,
             ],
             array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
         );
     }
 
-    public function testEmtpyConstructorIsMarkedAsExevutable(): void
+    public function testEmtpyConstructorIsMarkedAsExecutable(): void
     {
         $file = TEST_FILES_PATH . 'source_with_empty_constructor.php';
 
@@ -387,6 +384,20 @@ final class RawCodeCoverageDataTest extends TestCase
                 6,
                 7,
                 30,
+            ],
+            array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
+        );
+    }
+
+    public function testEachCaseInMatchExpressionIsMarkedAsExecutable(): void
+    {
+        $file = TEST_FILES_PATH . 'source_with_match_expression.php';
+
+        $this->assertEquals(
+            [
+                14,
+                20,
+                25,
             ],
             array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
         );

--- a/tests/tests/Data/RawCodeCoverageDataTest.php
+++ b/tests/tests/Data/RawCodeCoverageDataTest.php
@@ -389,6 +389,9 @@ final class RawCodeCoverageDataTest extends TestCase
         );
     }
 
+    /**
+     * @requires PHP 8.0
+     */
     public function testEachCaseInMatchExpressionIsMarkedAsExecutable(): void
     {
         $file = TEST_FILES_PATH . 'source_with_match_expression.php';


### PR DESCRIPTION
Fix https://github.com/sebastianbergmann/php-code-coverage/issues/904
Fix https://github.com/sebastianbergmann/php-code-coverage/issues/905