### PR TITLE
Fix phpdoc of internal private property

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -77,7 +77,7 @@ final class CodeCoverage
     private $ignoreDeprecatedCode = false;
 
     /**
-     * @var PhptTestCase|string|TestCase
+     * @var PhptTestCase|string|TestCase|null
      */
     private $currentId;
 


### PR DESCRIPTION
the property is set to null in https://github.com/sebastianbergmann/php-code-coverage/blob/9.2.15/src/CodeCoverage.php#L224, thus null should be in the phpdoc type