### PR TITLE
Use consistent color in first column of HTML Report

### DIFF
--- a/src/Report/Html/Renderer/Template/file_item.html.dist
+++ b/src/Report/Html/Renderer/Template/file_item.html.dist
@@ -1,5 +1,5 @@
       <tr>
-       <td class="{{classes_level}}">{{name}}</td>
+       <td class="{{lines_level}}">{{name}}</td>
        <td class="{{lines_level}} big">{{lines_bar}}</td>
        <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
        <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>

--- a/src/Report/Html/Renderer/Template/file_item_branch.html.dist
+++ b/src/Report/Html/Renderer/Template/file_item_branch.html.dist
@@ -1,5 +1,5 @@
       <tr>
-       <td class="{{classes_level}}">{{name}}</td>
+       <td class="{{lines_level}}">{{name}}</td>
        <td class="{{lines_level}} big">{{lines_bar}}</td>
        <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
        <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>

--- a/src/Report/Html/Renderer/Template/method_item.html.dist
+++ b/src/Report/Html/Renderer/Template/method_item.html.dist
@@ -1,5 +1,5 @@
       <tr>
-       <td class="{{methods_level}}">{{name}}</td>
+       <td class="{{lines_level}}">{{name}}</td>
        <td class="{{lines_level}} big">{{lines_bar}}</td>
        <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
        <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>

--- a/src/Report/Html/Renderer/Template/method_item_branch.html.dist
+++ b/src/Report/Html/Renderer/Template/method_item_branch.html.dist
@@ -1,5 +1,5 @@
       <tr>
-       <td class="{{methods_level}}">{{name}}</td>
+       <td class="{{lines_level}}">{{name}}</td>
        <td class="{{lines_level}} big">{{lines_bar}}</td>
        <td class="{{lines_level}} small"><div align="right">{{lines_executed_percent}}</div></td>
        <td class="{{lines_level}} small"><div align="right">{{lines_number}}</div></td>

--- a/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
+++ b/tests/_files/Report/HTML/CoverageForBankAccount/BankAccount.php.html
@@ -42,7 +42,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="danger">Total</td>
+       <td class="warning">Total</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>
@@ -71,7 +71,7 @@
       </tr>
 
       <tr>
-       <td class="danger">BankAccount</td>
+       <td class="warning">BankAccount</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>

--- a/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
+++ b/tests/_files/Report/HTML/CoverageForFileWithIgnoredLines/source_with_ignore.php.html
@@ -42,7 +42,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="success">Total</td>
        <td class="success big">       <div class="progress">
          <div class="progress-bar bg-success" role="progressbar" aria-valuenow="100.00" aria-valuemin="0" aria-valuemax="100" style="width: 100.00%">
            <span class="sr-only">100.00% covered (success)</span>

--- a/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="danger">Total</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="danger">Total</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
+++ b/tests/_files/Report/HTML/PHP80AndBelow/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="danger">Total</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="danger">Total</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_branch.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="danger">Total</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
+++ b/tests/_files/Report/HTML/PHP81AndUp/PathCoverageForSourceWithoutNamespace/source_without_namespace.php_path.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="">Total</td>
+       <td class="danger">Total</td>
        <td class="danger big">       <div class="progress">
          <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="0.00" aria-valuemin="0" aria-valuemax="100" style="width: 0.00%">
            <span class="sr-only">0.00% covered (danger)</span>

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="danger">Total</td>
+       <td class="warning">Total</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>
@@ -89,7 +89,7 @@
       </tr>
 
       <tr>
-       <td class="danger">BankAccount</td>
+       <td class="warning">BankAccount</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_branch.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_branch.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="danger">Total</td>
+       <td class="warning">Total</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>
@@ -89,7 +89,7 @@
       </tr>
 
       <tr>
-       <td class="danger">BankAccount</td>
+       <td class="warning">BankAccount</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>

--- a/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_path.html
+++ b/tests/_files/Report/HTML/PathCoverageForBankAccount/BankAccount.php_path.html
@@ -44,7 +44,7 @@
      </thead>
      <tbody>
       <tr>
-       <td class="danger">Total</td>
+       <td class="warning">Total</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>
@@ -89,7 +89,7 @@
       </tr>
 
       <tr>
-       <td class="danger">BankAccount</td>
+       <td class="warning">BankAccount</td>
        <td class="warning big">       <div class="progress">
          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="55.56" aria-valuemin="0" aria-valuemax="100" style="width: 55.56%">
            <span class="sr-only">55.56% covered (warning)</span>


### PR DESCRIPTION
Fixes #926.

The first column in the HTML Report will now be colored by the "Lines"
coverage level regardless of view (Directory vs. File) or item type
(Directory, File, Class, or Method).

While this is somewhat a matter of preference, I think the following
arguments support this change:

* Prior to #900, the first column was always colored the same as the
  second column. This change restores that pattern since the second
  column is always "Lines" as of #900.

* In the File view, the first column for Class and Method items were
  colored by "Class" and "Method" coverage respectively. This meant
  that they were only ever 0/1 or 1/1 (red or green). By switching to
  "Lines" coverage for both, the coloring can be more granular.

Previous behavior:
![image](https://user-images.githubusercontent.com/846186/185691020-0f98ae49-50bb-4474-b6c3-3bc827f79cc3.png)

New behavior:
![image](https://user-images.githubusercontent.com/846186/185693375-2ae86330-3586-4f6c-a2c5-36227381a056.png)
