### PR TITLE
Reorder checks in Filter::isExcluded to touch the FS only when needed

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -100,11 +100,7 @@ final class Filter
 
     public function isExcluded(string $filename): bool
     {
-        if (!$this->isFile($filename)) {
-            return true;
-        }
-
-        return !isset($this->files[$filename]);
+        return !isset($this->files[$filename]) || !$this->isFile($filename);
     }
 
     /**


### PR DESCRIPTION
This change reduces `is_file` calls in short coverage requests significantly, as a lot of `is_file` calls of (normally excluded/not-included) vendor files will not be needed.

Also reduces `Filter::$isFileCache` cache size.