### PR TITLE
Fix FS caching with open_basedir

### DIFF
--- a/src/StaticAnalysis/CachingFileAnalyser.php
+++ b/src/StaticAnalysis/CachingFileAnalyser.php
@@ -9,15 +9,13 @@
  */
 namespace SebastianBergmann\CodeCoverage\StaticAnalysis;
 
-use function assert;
 use function crc32;
 use function file_get_contents;
 use function file_put_contents;
 use function is_file;
 use function serialize;
-use GlobIterator;
 use SebastianBergmann\CodeCoverage\Util\Filesystem;
-use SplFileInfo;
+use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
@@ -172,10 +170,8 @@ final class CachingFileAnalyser implements FileAnalyser
     {
         $buffer = '';
 
-        foreach (new GlobIterator(__DIR__ . '/*.php') as $file) {
-            assert($file instanceof SplFileInfo);
-
-            $buffer .= file_get_contents($file->getPathname());
+        foreach ((new FileIteratorFacade())->getFilesAsArray(__DIR__, '.php') as $file) {
+            $buffer .= file_get_contents($file);
         }
 
         self::$cacheVersion = (string) crc32($buffer);


### PR DESCRIPTION
`GlobIterator(__DIR__ . '/*.php')` is not working /w open_basedir set in PHP 7.4 - 8.1

in upcoming PHP 8.2 it was fixed in https://github.com/php/php-src/pull/9120

we can simply use `SebastianBergmann\FileIterator\Facade` as in `Filter` class, this FS iterator is working /w open_basedir and it very optimized