### PR TITLE
Cache static analysis in system temp directory by default

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -22,6 +22,7 @@ use function get_class;
 use function is_array;
 use function is_file;
 use function sort;
+use function sys_get_temp_dir;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\Util\Test;
@@ -121,6 +122,10 @@ final class CodeCoverage
         $this->filter = $filter;
         $this->data   = new ProcessedCodeCoverageData;
         $this->wizard = new Wizard;
+
+        if (@is_writable(sys_get_temp_dir())) {
+            $this->cacheDirectory = sys_get_temp_dir() . '/phpunit/coverage-cache';
+        }
     }
 
     /**


### PR DESCRIPTION
Starting with https://github.com/sebastianbergmann/php-code-coverage/pull/892 (released in 9.2.10) static analysis is used for every coverage run which implies there is an huge analysis overhead.

Projects that run coverage analysis in multiple separate processes need about 4x more time to analyse since 9.2.10 release.

Same was reported also here: https://github.com/sebastianbergmann/php-code-coverage/pull/892#discussion_r802971069

This PR set system temp directory for caching by default. If user wants, he can disable the caching or change the caching using existing method. But for general usage, hash based cache does not impose any issues and the speedup in consequent runs in significant.