### PR TITLE
Fix cobertura package name

### DIFF
--- a/src/Report/Cobertura.php
+++ b/src/Report/Cobertura.php
@@ -25,7 +25,7 @@ final class Cobertura
     /**
      * @throws WriteOperationFailedException
      */
-    public function process(CodeCoverage $coverage, ?string $target = null, ?string $name = null): string
+    public function process(CodeCoverage $coverage, ?string $target = null): string
     {
         $time = (string) time();
 
@@ -84,9 +84,8 @@ final class Cobertura
 
             $packageElement    = $document->createElement('package');
             $packageComplexity = 0;
-            $packageName       = $name ?? '';
 
-            $packageElement->setAttribute('name', $packageName);
+            $packageElement->setAttribute('name', str_replace($report->pathAsString() . DIRECTORY_SEPARATOR, '', $item->pathAsString()));
 
             $linesValid   = $item->numberOfExecutableLines();
             $linesCovered = $item->numberOfExecutedLines();

--- a/tests/_files/BankAccount-cobertura-line.xml
+++ b/tests/_files/BankAccount-cobertura-line.xml
@@ -5,7 +5,7 @@
     <source>%s</source>
   </sources>
   <packages>
-    <package name="BankAccount" line-rate="0.55555555555556" branch-rate="0" complexity="5">
+    <package name="BankAccount.php" line-rate="0.55555555555556" branch-rate="0" complexity="5">
       <classes>
         <class name="BankAccount" filename="BankAccount.php" line-rate="0.55555555555556" branch-rate="0" complexity="5">
           <methods>

--- a/tests/_files/BankAccount-cobertura-path.xml
+++ b/tests/_files/BankAccount-cobertura-path.xml
@@ -5,7 +5,7 @@
     <source>%s</source>
   </sources>
   <packages>
-    <package name="BankAccount" line-rate="0.55555555555556" branch-rate="0.42857142857143" complexity="5">
+    <package name="BankAccount.php" line-rate="0.55555555555556" branch-rate="0.42857142857143" complexity="5">
       <classes>
         <class name="BankAccount" filename="BankAccount.php" line-rate="0.55555555555556" branch-rate="0.42857142857143" complexity="5">
           <methods>

--- a/tests/_files/class-with-anonymous-function-cobertura.xml
+++ b/tests/_files/class-with-anonymous-function-cobertura.xml
@@ -5,7 +5,7 @@
     <source>%s</source>
   </sources>
   <packages>
-    <package name="" line-rate="1" branch-rate="0" complexity="1">
+    <package name="source_with_class_and_anonymous_function.php" line-rate="1" branch-rate="0" complexity="1">
       <classes>
         <class name="CoveredClassWithAnonymousFunctionInStaticMethod" filename="source_with_class_and_anonymous_function.php" line-rate="1" branch-rate="0" complexity="1">
           <methods>

--- a/tests/_files/class-with-outside-function-cobertura.xml
+++ b/tests/_files/class-with-outside-function-cobertura.xml
@@ -5,7 +5,7 @@
     <source>%s</source>
   </sources>
   <packages>
-    <package name="" line-rate="0.75" branch-rate="0" complexity="3">
+    <package name="source_with_class_and_outside_function.php" line-rate="0.75" branch-rate="0" complexity="3">
       <classes>
         <class name="ClassInFileWithOutsideFunction" filename="source_with_class_and_outside_function.php" line-rate="1" branch-rate="0" complexity="1">
           <methods>

--- a/tests/_files/ignored-lines-cobertura.xml
+++ b/tests/_files/ignored-lines-cobertura.xml
@@ -5,7 +5,7 @@
     <source>%s</source>
   </sources>
   <packages>
-    <package name="" line-rate="1" branch-rate="0" complexity="2">
+    <package name="source_with_ignore.php" line-rate="1" branch-rate="0" complexity="2">
       <classes>
         <class name="Foo" filename="source_with_ignore.php" line-rate="0" branch-rate="0" complexity="1">
           <methods/>

--- a/tests/tests/Report/CoberturaTest.php
+++ b/tests/tests/Report/CoberturaTest.php
@@ -22,7 +22,7 @@ final class CoberturaTest extends TestCase
 
         $this->assertStringMatchesFormatFile(
             TEST_FILES_PATH . 'BankAccount-cobertura-line.xml',
-            $cobertura->process($this->getLineCoverageForBankAccount(), null, 'BankAccount')
+            $cobertura->process($this->getLineCoverageForBankAccount(), null)
         );
     }
 
@@ -32,7 +32,7 @@ final class CoberturaTest extends TestCase
 
         $this->assertStringMatchesFormatFile(
             TEST_FILES_PATH . 'BankAccount-cobertura-path.xml',
-            $cobertura->process($this->getPathCoverageForBankAccount(), null, 'BankAccount')
+            $cobertura->process($this->getPathCoverageForBankAccount(), null)
         );
     }
 


### PR DESCRIPTION
In certain utilities that parse Cobertura files they look to the `<Package name=` attribute. In PHPUnit this attribute is always empty (null)

This causes results to look like the following (in this parser at least):
![image](https://user-images.githubusercontent.com/564256/189450835-75bf9a96-8d7f-45f2-aae1-4b89d5011c5c.png)

As you can tell this makes no sense (The parser on the other end adds "[filename] Package 1+n" whenever it encounters an empty package name)

See: https://github.com/sebastianbergmann/phpunit/blob/main/src/TextUI/TestRunner.php#L479

The third parameter is never passed.

It appears that the Cobertura report generator was copied from the Clover report generator but they are not one-in-the same. If `$name` was properly set in the Cobertura report then every "package" would have the same name. This would confuse Cobertura parsers because the way PHPUnit works with each package is it's essentially each `$report` therefore we should be setting the packageName the same as the filename (or the class but filename seems more flexible when the file contains no classes)

Summary:
In a Clover file the "name" attribute is global, see: https://github.com/sebastianbergmann/php-code-coverage/blob/main/src/Report/Clover.php#L46

In Cobertura the "name" attribute is attached to PackageName and a package is generated for each report.

This change isn't really breaking because if name would have ever been passed it would have been added to each package and completely confused any parser (worse than it is now)