### PR TITLE
Fix coverage for uncovered files with arrays

### DIFF
--- a/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
@@ -10,9 +10,7 @@
 namespace SebastianBergmann\CodeCoverage\StaticAnalysis;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
-use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\CallLike;
@@ -150,22 +148,6 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             return [$node->dim->getStartLine()];
         }
 
-        if ($node instanceof Array_) {
-            $startLine = $node->getStartLine();
-
-            if (isset($this->executableLines[$startLine])) {
-                return [];
-            }
-
-            if ([] === $node->items) {
-                return [$node->getEndLine()];
-            }
-
-            if ($node->items[0] instanceof ArrayItem) {
-                return [$node->items[0]->getStartLine()];
-            }
-        }
-
         if ($node instanceof ClassMethod) {
             if ($node->name->name !== '__construct') {
                 return [];
@@ -235,7 +217,6 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
     {
         return $node instanceof Assign ||
                $node instanceof ArrayDimFetch ||
-               $node instanceof Array_ ||
                $node instanceof BinaryOp ||
                $node instanceof Break_ ||
                $node instanceof CallLike ||

--- a/tests/_files/source_with_return_and_array_with_scalars.php
+++ b/tests/_files/source_with_return_and_array_with_scalars.php
@@ -62,4 +62,24 @@ class Foo
         return
             ;
     }
+
+    /**
+     * Array expression must not add executable line to make uncovered
+     * output consistent with output from real coverage driver like Xdebug.
+     *
+     * @see https://github.com/sebastianbergmann/php-code-coverage/pull/938
+     */
+    public function nineNestedArray(): array
+    {
+        return [
+            [],
+            [[]],
+            [[
+                'test',
+                'test' => [
+                    [[[false]]]
+                ]
+            ]],
+        ];
+    }
 }

--- a/tests/tests/Data/RawCodeCoverageDataTest.php
+++ b/tests/tests/Data/RawCodeCoverageDataTest.php
@@ -272,7 +272,6 @@ final class RawCodeCoverageDataTest extends TestCase
             [
                 12,
                 14,
-                15,
                 16,
                 18,
             ],
@@ -300,7 +299,6 @@ final class RawCodeCoverageDataTest extends TestCase
             [
                 7,
                 9,
-                10,
                 11,
                 13,
             ],
@@ -342,7 +340,6 @@ final class RawCodeCoverageDataTest extends TestCase
                 25,
                 28,
                 31,
-                36,
                 40,
                 46,
                 48,
@@ -364,7 +361,6 @@ final class RawCodeCoverageDataTest extends TestCase
                 117,
                 120,
                 123,
-                125, // This shouldn't be marked as LoC, but it's high unlikely to happen IRL to have $var = []; on multiple lines
                 132,
                 135,
                 139,
@@ -415,14 +411,15 @@ final class RawCodeCoverageDataTest extends TestCase
 
         $this->assertEquals(
             [
-                8,
+                7,
                 15,
-                24,
+                22,
                 30,
-                40,
+                39,
                 47,
                 54,
                 63,
+                74,
             ],
             array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
         );


### PR DESCRIPTION
`PhpParser\Node\Expr\Array_` is not an executable the same as any scalar

introduced in https://github.com/sebastianbergmann/php-code-coverage/pull/909/files

fixes https://github.com/sebastianbergmann/php-code-coverage/issues/942

also fixes https://github.com/sebastianbergmann/php-code-coverage/pull/909/files#r820517185