### PR TITLE
Fix PHP CS Fixer deprecated config

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -151,8 +151,7 @@ $config->setFinder($finder)
         'no_superfluous_phpdoc_tags' => [
             'allow_mixed' => true,
         ],
-        'no_trailing_comma_in_list_call' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,


### PR DESCRIPTION
```
PHP CS Fixer 3.11.0 (7dcdea3) Oliva by Fabien Potencier and Dariusz Ruminski.

Checked all files in 4.432 seconds, 22.551 MB memory used

Detected deprecations in use:
- Rule "no_trailing_comma_in_list_call" is deprecated. Use "no_trailing_comma_in_singleline" instead.
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.
```