### PR TITLE
Stub: fix wrong return type

### DIFF
--- a/tests/_files/source_with_return_and_array_with_scalars.php
+++ b/tests/_files/source_with_return_and_array_with_scalars.php
@@ -48,7 +48,7 @@ class Foo
         ;
     }
 
-    public function seventh(): int
+    public function seventh(): string
     {
         return
             self


### PR DESCRIPTION
This fix is needed when debugging the test suite itself