### PR TITLE
Fix: return with multiline constant expr only must contain the last line

### DIFF
--- a/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
@@ -135,6 +135,17 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
      */
     private function getLines(Node $node): array
     {
+        if ($node instanceof BinaryOp) {
+            if (($node->left instanceof Node\Scalar ||
+                $node->left instanceof Node\Expr\ConstFetch) &&
+                ($node->right instanceof Node\Scalar ||
+                $node->right instanceof Node\Expr\ConstFetch)) {
+                return [$node->right->getStartLine()];
+            }
+
+            return [];
+        }
+
         if ($node instanceof Cast ||
             $node instanceof PropertyFetch ||
             $node instanceof NullsafePropertyFetch ||

--- a/tests/_files/source_with_multiline_constant_return.php
+++ b/tests/_files/source_with_multiline_constant_return.php
@@ -1,0 +1,247 @@
+<?php
+
+class Foo
+{
+    public function BitwiseAnd(): int
+    {
+        return
+            1
+            &
+            1
+        ;
+    }
+
+    public function BitwiseOr(): int
+    {
+        return
+            1
+            |
+            1
+        ;
+    }
+
+    public function BitwiseXor(): int
+    {
+        return
+            1
+            ^
+            1
+        ;
+    }
+
+    public function BooleanAnd(): bool
+    {
+        return
+            true
+            &&
+            false
+        ;
+    }
+
+    public function BooleanOr(): bool
+    {
+        return
+            false
+            ||
+            true
+        ;
+    }
+
+    public function Coalesce(): bool
+    {
+        return
+            true
+            ??
+            false
+        ;
+    }
+
+    public function Concat(): string
+    {
+        return
+            'foo'
+            .
+            'bar'
+        ;
+    }
+
+    public function Div(): int
+    {
+        return
+            2
+            /
+            1
+        ;
+    }
+
+    public function Equal(): bool
+    {
+        return
+            2
+            ==
+            1
+        ;
+    }
+
+    public function Greater(): bool
+    {
+        return
+            2
+            >
+            1
+        ;
+    }
+
+    public function GreaterOrEqual(): bool
+    {
+        return
+            2
+            >=
+            1
+        ;
+    }
+
+    public function Identical(): bool
+    {
+        return
+            2
+            ===
+            1
+        ;
+    }
+
+    public function LogicalAnd(): bool
+    {
+        return
+            true
+            and
+            false
+        ;
+    }
+
+    public function LogicalOr(): bool
+    {
+        return
+            true
+            or
+            false
+        ;
+    }
+
+    public function LogicalXor(): bool
+    {
+        return
+            true
+            xor
+            false
+        ;
+    }
+
+    public function Minus(): int
+    {
+        return
+            2
+            -
+            1
+        ;
+    }
+
+    public function Mod(): int
+    {
+        return
+            2
+            %
+            1
+        ;
+    }
+
+    public function Mul(): int
+    {
+        return
+            2
+            *
+            1
+        ;
+    }
+
+    public function NotEqual(): bool
+    {
+        return
+            2
+            !=
+            1
+        ;
+    }
+
+    public function NotIdentical(): bool
+    {
+        return
+            2
+            !==
+            1
+        ;
+    }
+
+    public function Plus(): int
+    {
+        return
+            2
+            +
+            1
+        ;
+    }
+
+    public function Pow(): int
+    {
+        return
+            2
+            **
+            1
+        ;
+    }
+
+    public function ShiftLeft(): int
+    {
+        return
+            2
+            <<
+            1
+        ;
+    }
+
+    public function ShiftRight(): int
+    {
+        return
+            2
+            >>
+            1
+        ;
+    }
+
+    public function Smaller(): bool
+    {
+        return
+            2
+            <
+            1
+        ;
+    }
+
+    public function SmallerOrEqual(): bool
+    {
+        return
+            2
+            <=
+            1
+        ;
+    }
+
+    public function Spaceship(): int
+    {
+        return
+            2
+            <=>
+            1
+        ;
+    }
+}

--- a/tests/tests/Data/RawCodeCoverageDataTest.php
+++ b/tests/tests/Data/RawCodeCoverageDataTest.php
@@ -361,7 +361,6 @@ final class RawCodeCoverageDataTest extends TestCase
                 99,
                 101,
                 116,
-                117,
                 120,
                 123,
                 125, // This shouldn't be marked as LoC, but it's high unlikely to happen IRL to have $var = []; on multiple lines
@@ -423,6 +422,44 @@ final class RawCodeCoverageDataTest extends TestCase
                 47,
                 54,
                 63,
+            ],
+            array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
+        );
+    }
+
+    public function testReturnStatementWithConstantExprOnlyReturnTheLineOfLast(): void
+    {
+        $file = TEST_FILES_PATH . 'source_with_multiline_constant_return.php';
+
+        $this->assertEquals(
+            [
+                10,
+                19,
+                28,
+                37,
+                46,
+                55,
+                64,
+                73,
+                82,
+                91,
+                100,
+                109,
+                118,
+                127,
+                136,
+                145,
+                154,
+                163,
+                172,
+                181,
+                190,
+                199,
+                208,
+                217,
+                226,
+                235,
+                244,
             ],
             array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
         );


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/php-code-coverage/issues/946