### PR TITLE
Add failing test for parent constructor call coverage

### DIFF
--- a/tests/_files/source_with_parent_constructor_call.php
+++ b/tests/_files/source_with_parent_constructor_call.php
@@ -1,0 +1,12 @@
+<?php
+
+class Foo extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'some message',
+            42
+        );
+    }
+}

--- a/tests/tests/Data/RawCodeCoverageDataTest.php
+++ b/tests/tests/Data/RawCodeCoverageDataTest.php
@@ -694,4 +694,18 @@ final class RawCodeCoverageDataTest extends TestCase
             $coverage->functionCoverage()[$filename]
         );
     }
+
+    public function testParentConstructorCallIsCovered(): void
+    {
+        $file = TEST_FILES_PATH . 'source_with_parent_constructor_call.php';
+
+        $this->assertEquals(
+            [
+                7,
+                8,
+                9,
+            ],
+            array_keys(RawCodeCoverageData::fromUncoveredFile($file, new ParsingFileAnalyser(true, true))->lineCoverage()[$file])
+        );
+    }
 }


### PR DESCRIPTION
Since a86b33141ad983576383e9b24d75a3b120651dc1 has been commited, a call to an exception's parent constructor will not mark the `$code` argument as covered.

I guess adding back `\PhpParser\Node\Scalar` to the list of [`\SebastianBergmann\CodeCoverage\StaticAnalysis\ExecutableLinesFindingVisitor::isExecutable`](https://github.com/sebastianbergmann/php-code-coverage/blob/a687b9bad537095ea139c3b5db235f500620ca6a/src/StaticAnalysis/ExecutableLinesFindingVisitor.php#L306-L340) would not be a correct fix as it would break what @Slamdunk did in a86b33141ad983576383e9b24d75a3b120651dc1. I do not know the codebase enough to be able to bring a correct fix, so I start by adding a failing test and would love to have some feedback on how to do it properly.

For reference, I ran into this issue when using Infection; see infection/infection#1734.

---

I rarely contribute to the PHPUnit ecosystem, so I'll take this opportunity to thank the contributors for bringing such a reliable testing framework to PHP. 🤗 