### PR TITLE
Throw: mark as executable expression line regardless of type

### DIFF
--- a/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/ExecutableLinesFindingVisitor.php
@@ -97,7 +97,6 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             $node instanceof Node\Stmt\Namespace_ ||
             $node instanceof Node\Stmt\Nop ||
             $node instanceof Node\Stmt\Switch_ ||
-            $node instanceof Node\Stmt\Throw_ ||
             $node instanceof Node\Stmt\TryCatch ||
             $node instanceof Node\Stmt\Use_ ||
             $node instanceof Node\Stmt\UseUse ||
@@ -108,6 +107,12 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             $node instanceof Node\Name ||
             $node instanceof Node\Param ||
             $node instanceof Node\Scalar) {
+            return;
+        }
+
+        if ($node instanceof Node\Stmt\Throw_) {
+            $this->setLineBranch($node->expr->getEndLine(), $node->expr->getEndLine(), ++$this->nextBranch);
+
             return;
         }
 

--- a/tests/_files/source_for_branched_exec_lines.php
+++ b/tests/_files/source_for_branched_exec_lines.php
@@ -310,8 +310,12 @@ class MyClass
         try {
             ++$var;                         // +1
             throw
-            new                             // +1
+            new                             // +2
             \Exception()                    // 0
+            ;
+            $myex = new \Exception();       // +1
+            throw
+                $myex                       // +1
             ;
             ++$var;                         // +1
         } catch (\Exception $exception) {   // +1


### PR DESCRIPTION
Fix bug found in https://github.com/infection/infection/issues/1778