### PR TITLE
Fix coverage failure in case of an invalid file

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -21,6 +21,7 @@ use function explode;
 use function get_class;
 use function is_array;
 use function sort;
+use Error;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\Util\Test;
@@ -550,7 +551,11 @@ final class CodeCoverage
 
         foreach ($uncoveredFiles as $uncoveredFile) {
             if ($this->filter->isFile($uncoveredFile)) {
-                include_once $uncoveredFile;
+                try {
+                    include_once $uncoveredFile;
+                } catch (Error $e) {
+                    // Include may fail if file content is not valid (due to implementing/extending non-existent class, ...)
+                }
             }
         }
 


### PR DESCRIPTION
My lib supports two incompatible versions of a dependency. Code for newer version extends class that does not exist in older one. Currently code coverage fails with `Uncaught Error: Class 'Latte\Extension' not found` https://github.com/orisai/localization/actions/runs/3766553046/jobs/6403184303

After applying the fix, coverage no longer fails. And file is correctly reported as uncovered.
https://github.com/orisai/localization/commit/a0f7a0b766c738d0df99eed52f8f529aceabb4f3
https://github.com/orisai/localization/actions/runs/3766885353