### PR TITLE
Add description to suggested composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
         "phpunit/phpunit": "^10.1"
     },
     "suggest": {
-        "ext-pcov": "*",
-        "ext-xdebug": "*"
+        "ext-pcov": "PHP extension that provides line coverage",
+        "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
The value in suggestions is not for the version (like in required) but for a descriptive test that can help developers in deciding if they should install the suggested package.

This hint will be show to developers when running `composer suggests`