### PR TITLE
Add option to ignore @covers annotation 

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -45,6 +45,7 @@ final class CodeCoverage
     private bool $checkForUnintentionallyCoveredCode = false;
     private bool $includeUncoveredFiles              = true;
     private bool $ignoreDeprecatedCode               = false;
+    private bool $ignoreCoversAnnotation             = false;
     private ?string $currentId                       = null;
     private ?TestSize $currentSize                   = null;
     private ProcessedCodeCoverageData $data;
@@ -278,6 +279,16 @@ final class CodeCoverage
         $this->ignoreDeprecatedCode = false;
     }
 
+    public function ignoreCoversAnnotation(): void
+    {
+        $this->ignoreCoversAnnotation = true;
+    }
+
+    public function doNotIgnoreCoversAnnotation(): void
+    {
+        $this->ignoreCoversAnnotation = false;
+    }
+
     /**
      * @psalm-assert-if-true !null $this->cacheDirectory
      */
@@ -344,6 +355,10 @@ final class CodeCoverage
      */
     private function applyCoversAndUsesFilter(RawCodeCoverageData $rawData, array|false $linesToBeCovered, array $linesToBeUsed, TestSize $size): void
     {
+        if ($this->ignoreCoversAnnotation) {
+            return;
+        }
+
         if ($linesToBeCovered === false) {
             $rawData->clear();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2001,4 +2001,73 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
         return $coverage;
     }
+
+    protected function getCoverageForFilesUseIgnoreCoversAnnotation(?bool $ignoreCoversAnnotation): CodeCoverage
+    {
+        $data = $this->getLineCoverageXdebugDataForBankAccount();
+
+        $stub = $this->createStub(Driver::class);
+
+        $stub->method('stop')
+            ->will($this->onConsecutiveCalls(...$data));
+
+        $filter = new Filter;
+        $filter->includeFile(TEST_FILES_PATH . 'BankAccount.php');
+        $filter->includeFile(TEST_FILES_PATH . 'NamespacedBankAccount.php');
+
+        $coverage = new CodeCoverage($stub, $filter);
+        if ($ignoreCoversAnnotation !== null) {
+            $ignoreCoversAnnotation ? $coverage->ignoreCoversAnnotation() : $coverage->doNotIgnoreCoversAnnotation();
+        }
+
+        $coverage->start(
+            'BankAccountTest::testBalanceIsInitiallyZero',
+            null,
+            true
+        );
+
+        $coverage->stop(
+            true,
+            null,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(6, 9)]
+        );
+
+        $coverage->start(
+            'BankAccountTest::testBalanceCannotBecomeNegative'
+        );
+
+        $coverage->stop(
+            true,
+            null,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(27, 32)]
+        );
+
+        $coverage->start(
+            'BankAccountTest::testBalanceCannotBecomeNegative2'
+        );
+
+        $coverage->stop(
+            true,
+            null,
+            [TEST_FILES_PATH . 'BankAccount.php' => range(20, 25)]
+        );
+
+        $coverage->start(
+            'BankAccountTest::testDepositWithdrawMoney'
+        );
+
+        $coverage->stop(
+            true,
+            null,
+            [
+                TEST_FILES_PATH . 'BankAccount.php' => array_merge(
+                    range(6, 9),
+                    range(20, 25),
+                    range(27, 32)
+                ),
+            ]
+        );
+
+        return $coverage;
+    }
 }

--- a/tests/_files/BankAccountWithUncoveredAndIgnoreCoversAnnotation-text-line.txt
+++ b/tests/_files/BankAccountWithUncoveredAndIgnoreCoversAnnotation-text-line.txt
@@ -1,0 +1,12 @@
+
+
+Code Coverage Report:   
+  %s
+                        
+ Summary:               
+  Classes: 50.00% (1/2) 
+  Methods: 50.00% (4/8) 
+  Lines:   50.00% (8/16)
+
+BankAccount
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% (  8/  8)

--- a/tests/tests/Report/TextTest.php
+++ b/tests/tests/Report/TextTest.php
@@ -96,4 +96,24 @@ final class TextTest extends TestCase
             str_replace(PHP_EOL, "\n", $text->process($this->getCoverageForFilesWithUncoveredExcluded()))
         );
     }
+
+    /**
+     * @dataProvider ignoreCoversAnnotationProvider
+     */
+    public function testWithIgnoreCoversAnnotationWhenConfiguredTest($isUseIgnoreCoversAnnotation, $file): void
+    {
+        $text = new Text(Thresholds::default(), false, false);
+        $codeCoverage = $this->getCoverageForFilesUseIgnoreCoversAnnotation($isUseIgnoreCoversAnnotation);
+
+        $this->assertStringMatchesFormatFile($file, str_replace(PHP_EOL, "\n", $text->process($codeCoverage)));
+    }
+
+    private function ignoreCoversAnnotationProvider(): array
+    {
+        return [
+            'with' => [true, TEST_FILES_PATH . 'BankAccountWithUncoveredAndIgnoreCoversAnnotation-text-line.txt'],
+            'without' => [false, TEST_FILES_PATH . 'BankAccountWithUncovered-text-line.txt'],
+            'default' => [null, TEST_FILES_PATH . 'BankAccountWithUncovered-text-line.txt'],
+        ];
+    }
 }


### PR DESCRIPTION
Reincarnation of the https://github.com/sebastianbergmann/php-code-coverage/pull/573 by @BackEndTea

See also https://github.com/sebastianbergmann/php-code-coverage/issues/571

So, another attempt to achieve this feature)