### PR TITLE
Fix: Use `@psalm-var` instead of `@psalm-return`

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -32,7 +32,7 @@ final class File extends AbstractNode
     private array $functions           = [];
 
     /**
-     * @psalm-return array{linesOfCode: int, commentLinesOfCode: int, nonCommentLinesOfCode: int}
+     * @psalm-var array{linesOfCode: int, commentLinesOfCode: int, nonCommentLinesOfCode: int}
      */
     private readonly array $linesOfCode;
     private ?int $numClasses         = null;


### PR DESCRIPTION
This pull request

- [x] uses `@psalm-var` instead of `@psalm-return` in the DocBlock for a field