### PR TITLE
Add cache to Coverage Report Directory

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -114,6 +114,11 @@ final class CodeCoverage
      */
     private $cacheDirectory;
 
+    /**
+     * @var ?Directory
+     */
+    private $cacheReport;
+
     public function __construct(Driver $driver, Filter $filter)
     {
         $this->driver = $driver;
@@ -127,7 +132,10 @@ final class CodeCoverage
      */
     public function getReport(): Directory
     {
-        return (new Builder($this->analyser()))->build($this);
+        if (!$this->cacheReport) {
+            $this->cacheReport = (new Builder($this->analyser()))->build($this);
+        }
+        return clone $this->cacheReport;
     }
 
     /**


### PR DESCRIPTION
Add cache to Coverage Report Directory 

- To avoid issues with multiple reporter when using PHP fibers when generate a second report
- Optimize the speed generation of next reports
