### PR TITLE
[CSS] Changed the x direction of scrollbox from hidden to scroll

### DIFF
--- a/src/Report/Html/Renderer/Template/css/style.css
+++ b/src/Report/Html/Renderer/Template/css/style.css
@@ -120,7 +120,7 @@ svg text {
 
 .scrollbox {
  height:245px;
- overflow-x:hidden;
+ overflow-x:scroll;
  overflow-y:scroll;
 }
 


### PR DESCRIPTION
Hi

When checking project risks on the dashboard, if the class name is too long, the table will be cut off and CRUP cannot be checked.

It seemed like it would be a good idea to simply change hidden to scroll using CSS, so I would like to make such a suggestion. Is the target branch 9.2 ok?

Best regards.

cc: @sebastianbergmann 