### PR TITLE
Implement processed code coverage data mapper

### DIFF
--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -18,10 +18,12 @@ namespace SebastianBergmann\CodeCoverage\Data;
  */
 final class ProcessedCodeCoverageDataMapper
 {
+    const KEY_LINE_COVERAGE = 'line_coverage';
+
     public function toJson(ProcessedCodeCoverageData $processedCodeCoverageData): string
     {
         $arrayMapping = [
-            'line_coverage' => $processedCodeCoverageData->lineCoverage(),
+            self::KEY_LINE_COVERAGE => $processedCodeCoverageData->lineCoverage(),
         ];
 
         return json_encode($arrayMapping);
@@ -33,7 +35,7 @@ final class ProcessedCodeCoverageDataMapper
         
         $processedCodeCoverageData = new ProcessedCodeCoverageData();
 
-        $processedCodeCoverageData->setLineCoverage($unserializedData['line_coverage']);
+        $processedCodeCoverageData->setLineCoverage($unserializedData[self::KEY_LINE_COVERAGE]);
 
         return $processedCodeCoverageData;
     }

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -33,6 +33,7 @@ final class ProcessedCodeCoverageDataMapper
 
     public function fromJson(string $json): ProcessedCodeCoverageData
     {
+        /** @var array<array-key, array<array-key, mixed>> */
         $unserializedData = json_decode($json, true);
         
         $processedCodeCoverageData = new ProcessedCodeCoverageData();

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -19,11 +19,13 @@ namespace SebastianBergmann\CodeCoverage\Data;
 final class ProcessedCodeCoverageDataMapper
 {
     const KEY_LINE_COVERAGE = 'lineCoverage';
+    const KEY_FUNCTION_COVERAGE = 'functionCoverage';
 
     public function toJson(ProcessedCodeCoverageData $processedCodeCoverageData): string
     {
         $arrayMapping = [
             self::KEY_LINE_COVERAGE => $processedCodeCoverageData->lineCoverage(),
+            self::KEY_FUNCTION_COVERAGE => $processedCodeCoverageData->functionCoverage(),
         ];
 
         return json_encode($arrayMapping);

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -26,5 +26,16 @@ final class ProcessedCodeCoverageDataMapper
 
         return json_encode($arrayMapping);
     }
+
+    public function fromJson(string $json): ProcessedCodeCoverageData
+    {
+        $unserializedData = json_decode($json, true);
+        
+        $processedCodeCoverageData = new ProcessedCodeCoverageData();
+
+        $processedCodeCoverageData->setLineCoverage($unserializedData['line_coverage']);
+
+        return $processedCodeCoverageData;
+    }
 }
 

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -9,6 +9,9 @@
  */
 namespace SebastianBergmann\CodeCoverage\Data;
 
+use function json_decode;
+use function json_encode;
+
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  *
@@ -18,13 +21,13 @@ namespace SebastianBergmann\CodeCoverage\Data;
  */
 final class ProcessedCodeCoverageDataMapper
 {
-    const KEY_LINE_COVERAGE = 'lineCoverage';
-    const KEY_FUNCTION_COVERAGE = 'functionCoverage';
+    public const KEY_LINE_COVERAGE     = 'lineCoverage';
+    public const KEY_FUNCTION_COVERAGE = 'functionCoverage';
 
     public function toJson(ProcessedCodeCoverageData $processedCodeCoverageData): string
     {
         $arrayMapping = [
-            self::KEY_LINE_COVERAGE => $processedCodeCoverageData->lineCoverage(),
+            self::KEY_LINE_COVERAGE     => $processedCodeCoverageData->lineCoverage(),
             self::KEY_FUNCTION_COVERAGE => $processedCodeCoverageData->functionCoverage(),
         ];
 
@@ -35,8 +38,8 @@ final class ProcessedCodeCoverageDataMapper
     {
         /** @var array<array-key, array<array-key, mixed>> */
         $unserializedData = json_decode($json, true);
-        
-        $processedCodeCoverageData = new ProcessedCodeCoverageData();
+
+        $processedCodeCoverageData = new ProcessedCodeCoverageData;
 
         $processedCodeCoverageData->setLineCoverage($unserializedData[self::KEY_LINE_COVERAGE]);
         $processedCodeCoverageData->setFunctionCoverage($unserializedData[self::KEY_FUNCTION_COVERAGE]);
@@ -44,4 +47,3 @@ final class ProcessedCodeCoverageDataMapper
         return $processedCodeCoverageData;
     }
 }
-

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Data;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
+ *
+ * @psalm-import-type XdebugFunctionCoverageType from \SebastianBergmann\CodeCoverage\Driver\XdebugDriver
+ *
+ * @psalm-type TestIdType = string
+ */
+final class ProcessedCodeCoverageDataMapper
+{
+    public function toJson(ProcessedCodeCoverageData $processedCodeCoverageData): string
+    {
+        $arrayMapping = [
+            'line_coverage' => $processedCodeCoverageData->lineCoverage(),
+        ];
+
+        return json_encode($arrayMapping);
+    }
+}
+

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -18,7 +18,7 @@ namespace SebastianBergmann\CodeCoverage\Data;
  */
 final class ProcessedCodeCoverageDataMapper
 {
-    const KEY_LINE_COVERAGE = 'line_coverage';
+    const KEY_LINE_COVERAGE = 'lineCoverage';
 
     public function toJson(ProcessedCodeCoverageData $processedCodeCoverageData): string
     {

--- a/src/Data/ProcessedCodeCoverageDataMapper.php
+++ b/src/Data/ProcessedCodeCoverageDataMapper.php
@@ -38,6 +38,7 @@ final class ProcessedCodeCoverageDataMapper
         $processedCodeCoverageData = new ProcessedCodeCoverageData();
 
         $processedCodeCoverageData->setLineCoverage($unserializedData[self::KEY_LINE_COVERAGE]);
+        $processedCodeCoverageData->setFunctionCoverage($unserializedData[self::KEY_FUNCTION_COVERAGE]);
 
         return $processedCodeCoverageData;
     }

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -47,16 +47,8 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     public function testFromJsonCoverageForBankAccount(): void
     {
-        // Doing it this way while the JSON format is being developed, though
-        // I expect we'd have a fixture file in the future
-        $coverage = $this->getLineCoverageForBankAccount()->getData();
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $json = $dataMapper->toJson($coverage);
-
-        // Instantiate a new data mapper to ensure we have no persisted state
-        // from the setup step
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $unserializedCoverage = $dataMapper->fromJson($json);
+        $coverage = $this->getPathCoverageForBankAccount()->getData();
+        $unserializedCoverage = $this->serializeAndUnserializeToJson($coverage);
 
         $this->assertEquals(
             $coverage->lineCoverage(),
@@ -71,16 +63,8 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     public function testFromJsonPathCoverageForBankAccount(): void
     {
-        // Doing it this way while the JSON format is being developed, though
-        // I expect we'd have a fixture file in the future
         $coverage = $this->getPathCoverageForBankAccount()->getData();
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $json = $dataMapper->toJson($coverage);
-
-        // Instantiate a new data mapper to ensure we have no persisted state
-        // from the setup step
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $unserializedCoverage = $dataMapper->fromJson($json);
+        $unserializedCoverage = $this->serializeAndUnserializeToJson($coverage);
 
         $this->assertEquals(
             $coverage->lineCoverage(),
@@ -99,6 +83,22 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         $json = $dataMapper->toJson($processedCodeCoverage);
 
         return json_decode($json, true);
+    }
+
+    /**
+    * Doing it this way while the JSON format is being developed, though I expect we'd have a
+    * fixture file in the future
+    **/
+    private function serializeAndUnserializeToJson(ProcessedCodeCoverageData $processedCodeCoverage): ProcessedCodeCoverageData
+    {
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $json = $dataMapper->toJson($processedCodeCoverage);
+
+        // Instantiate a new data mapper out of an abundance of caution to ensure we have no 
+        // persisted state from the serializing instance.
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+
+        return $dataMapper->fromJson($json);
     }
 }
 

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -13,7 +13,7 @@ use SebastianBergmann\CodeCoverage\TestCase;
 
 final class ProcessedCodeCoverageDataMapperTest extends TestCase
 {
-    public function testToJson(): void
+    public function testToJsonCoverageForBankAccount(): void
     {
         $coverage = $this->getLineCoverageForBankAccount()->getData();
         $dataMapper = new ProcessedCodeCoverageDataMapper();
@@ -27,7 +27,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         );
     }
 
-    public function testFromJson(): void
+    public function testFromJsonCoverageForBankAccount(): void
     {
         // Doing it this way while the JSON format is being developed, though
         // I expect we'd have a fixture file in the future

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Data;
+
+use SebastianBergmann\CodeCoverage\TestCase;
+
+final class ProcessedCodeCoverageDataMapperTest extends TestCase
+{
+    public function testToJson(): void
+    {
+        $coverage = $this->getLineCoverageForBankAccountForFirstTwoTests()->getData();
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $json = $dataMapper->toJson($coverage);
+
+        $decodedJson = json_decode($json, true);
+
+        $this->assertEquals(
+            $coverage->lineCoverage(),
+            $decodedJson['line_coverage'],
+        );
+    }
+}
+

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -9,10 +9,31 @@
  */
 namespace SebastianBergmann\CodeCoverage\Data;
 
+use SebastianBergmann\CodeCoverage\Report\Xml\Facade;
 use SebastianBergmann\CodeCoverage\TestCase;
+use FilesystemIterator;
 
 final class ProcessedCodeCoverageDataMapperTest extends TestCase
 {
+    private static string $TEST_REPORT_PATH_SOURCE;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$TEST_REPORT_PATH_SOURCE = TEST_FILES_PATH . 'Report' . DIRECTORY_SEPARATOR . 'XML';
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        foreach (new FilesystemIterator(self::$TEST_TMP_PATH) as $fileInfo) {
+            /* @var \SplFileInfo $fileInfo */
+            unlink($fileInfo->getPathname());
+        }
+    }
+
     public function testToJsonLineCoverageForBankAccount(): void
     {
         $coverage = $this->getLineCoverageForBankAccount()->getData();
@@ -77,6 +98,25 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         );
     }
 
+    /**
+    * I don't expect this test to survive in the PR, but I am trying to 
+    * produce the final XML format via the JSON serialization to ensure
+    * that I have everything I need in the JSON format.
+    */
+    public function testFromJsonLineCoverageForBankAccountToXml(): void
+    {
+        $coverage = $this->getLineCoverageForBankAccount();
+        $unserializedCoverage = $this->serializeAndUnserializeToJson($coverage->getData());
+        $coverage->setData($unserializedCoverage);
+
+        $expectedFilesPath = self::$TEST_REPORT_PATH_SOURCE . DIRECTORY_SEPARATOR . 'CoverageForBankAccount';
+
+        $xml = new Facade('1.0.0');
+        $xml->process($coverage, self::$TEST_TMP_PATH);
+
+        $this->assertFilesEquals($expectedFilesPath, self::$TEST_TMP_PATH);
+    }
+
     private function getDecodedJsonForProcessedCodeCoverage(ProcessedCodeCoverageData $processedCodeCoverage): array
     {
         $dataMapper = new ProcessedCodeCoverageDataMapper();
@@ -99,6 +139,33 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         $dataMapper = new ProcessedCodeCoverageDataMapper();
 
         return $dataMapper->fromJson($json);
+    }
+
+    private function assertFilesEquals(string $expectedFilesPath, string $actualFilesPath): void
+    {
+        $expectedFilesIterator = new FilesystemIterator($expectedFilesPath);
+        $actualFilesIterator   = new FilesystemIterator($actualFilesPath);
+
+        $this->assertEquals(
+            iterator_count($expectedFilesIterator),
+            iterator_count($actualFilesIterator),
+            'Generated files and expected files not match',
+        );
+
+        foreach ($expectedFilesIterator as $fileInfo) {
+            /* @var \SplFileInfo $fileInfo */
+            $filename = $fileInfo->getFilename();
+
+            $actualFile = $actualFilesPath . DIRECTORY_SEPARATOR . $filename;
+
+            $this->assertFileExists($actualFile);
+
+            $this->assertStringMatchesFormatFile(
+                $fileInfo->getPathname(),
+                file_get_contents($actualFile),
+                "{$filename} not match",
+            );
+        }
     }
 }
 

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -15,7 +15,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 {
     public function testToJson(): void
     {
-        $coverage = $this->getLineCoverageForBankAccountForFirstTwoTests()->getData();
+        $coverage = $this->getLineCoverageForBankAccount()->getData();
         $dataMapper = new ProcessedCodeCoverageDataMapper();
         $json = $dataMapper->toJson($coverage);
 
@@ -31,7 +31,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
     {
         // Doing it this way while the JSON format is being developed, though
         // I expect we'd have a fixture file in the future
-        $coverage = $this->getLineCoverageForBankAccountForFirstTwoTests()->getData();
+        $coverage = $this->getLineCoverageForBankAccount()->getData();
         $dataMapper = new ProcessedCodeCoverageDataMapper();
         $json = $dataMapper->toJson($coverage);
 

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -25,6 +25,11 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
             $coverage->lineCoverage(),
             $decodedJson[ProcessedCodeCoverageDataMapper::KEY_LINE_COVERAGE],
         );
+
+        $this->assertEquals(
+            $coverage->functionCoverage(),
+            $decodedJson[ProcessedCodeCoverageDataMapper::KEY_FUNCTION_COVERAGE],
+        );
     }
 
     public function testFromJsonCoverageForBankAccount(): void
@@ -43,6 +48,11 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         $this->assertEquals(
             $coverage->lineCoverage(),
             $unserializedCoverage->lineCoverage(),
+        );
+
+        $this->assertEquals(
+            $coverage->functionCoverage(),
+            $unserializedCoverage->functionCoverage(),
         );
     }
 }

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -26,5 +26,24 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
             $decodedJson['line_coverage'],
         );
     }
+
+    public function testFromJson(): void
+    {
+        // Doing it this way while the JSON format is being developed, though
+        // I expect we'd have a fixture file in the future
+        $coverage = $this->getLineCoverageForBankAccountForFirstTwoTests()->getData();
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $json = $dataMapper->toJson($coverage);
+
+        // Instantiate a new data mapper to ensure we have no persisted state
+        // from the setup step
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $unserializedCoverage = $dataMapper->fromJson($json);
+
+        $this->assertEquals(
+            $coverage->lineCoverage(),
+            $unserializedCoverage->lineCoverage(),
+        );
+    }
 }
 

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -16,10 +16,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
     public function testToJsonLineCoverageForBankAccount(): void
     {
         $coverage = $this->getLineCoverageForBankAccount()->getData();
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $json = $dataMapper->toJson($coverage);
-
-        $decodedJson = json_decode($json, true);
+        $decodedJson = $this->getDecodedJsonForProcessedCodeCoverage($coverage);
 
         $this->assertEquals(
             $coverage->lineCoverage(),
@@ -35,10 +32,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
     public function testToJsonPathCoverageForBankAccount(): void
     {
         $coverage = $this->getPathCoverageForBankAccount()->getData();
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $json = $dataMapper->toJson($coverage);
-
-        $decodedJson = json_decode($json, true);
+        $decodedJson = $this->getDecodedJsonForProcessedCodeCoverage($coverage);
 
         $this->assertEquals(
             $coverage->lineCoverage(),
@@ -97,6 +91,14 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
             $coverage->functionCoverage(),
             $unserializedCoverage->functionCoverage(),
         );
+    }
+
+    private function getDecodedJsonForProcessedCodeCoverage(ProcessedCodeCoverageData $processedCodeCoverage): array
+    {
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $json = $dataMapper->toJson($processedCodeCoverage);
+
+        return json_decode($json, true);
     }
 }
 

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -13,9 +13,28 @@ use SebastianBergmann\CodeCoverage\TestCase;
 
 final class ProcessedCodeCoverageDataMapperTest extends TestCase
 {
-    public function testToJsonCoverageForBankAccount(): void
+    public function testToJsonLineCoverageForBankAccount(): void
     {
         $coverage = $this->getLineCoverageForBankAccount()->getData();
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $json = $dataMapper->toJson($coverage);
+
+        $decodedJson = json_decode($json, true);
+
+        $this->assertEquals(
+            $coverage->lineCoverage(),
+            $decodedJson[ProcessedCodeCoverageDataMapper::KEY_LINE_COVERAGE],
+        );
+
+        $this->assertEquals(
+            $coverage->functionCoverage(),
+            $decodedJson[ProcessedCodeCoverageDataMapper::KEY_FUNCTION_COVERAGE],
+        );
+    }
+
+    public function testToJsonPathCoverageForBankAccount(): void
+    {
+        $coverage = $this->getPathCoverageForBankAccount()->getData();
         $dataMapper = new ProcessedCodeCoverageDataMapper();
         $json = $dataMapper->toJson($coverage);
 
@@ -37,6 +56,30 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         // Doing it this way while the JSON format is being developed, though
         // I expect we'd have a fixture file in the future
         $coverage = $this->getLineCoverageForBankAccount()->getData();
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $json = $dataMapper->toJson($coverage);
+
+        // Instantiate a new data mapper to ensure we have no persisted state
+        // from the setup step
+        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $unserializedCoverage = $dataMapper->fromJson($json);
+
+        $this->assertEquals(
+            $coverage->lineCoverage(),
+            $unserializedCoverage->lineCoverage(),
+        );
+
+        $this->assertEquals(
+            $coverage->functionCoverage(),
+            $unserializedCoverage->functionCoverage(),
+        );
+    }
+
+    public function testFromJsonPathCoverageForBankAccount(): void
+    {
+        // Doing it this way while the JSON format is being developed, though
+        // I expect we'd have a fixture file in the future
+        $coverage = $this->getPathCoverageForBankAccount()->getData();
         $dataMapper = new ProcessedCodeCoverageDataMapper();
         $json = $dataMapper->toJson($coverage);
 

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -9,9 +9,13 @@
  */
 namespace SebastianBergmann\CodeCoverage\Data;
 
+use function file_get_contents;
+use function iterator_count;
+use function json_decode;
+use function unlink;
+use FilesystemIterator;
 use SebastianBergmann\CodeCoverage\Report\Xml\Facade;
 use SebastianBergmann\CodeCoverage\TestCase;
-use FilesystemIterator;
 
 final class ProcessedCodeCoverageDataMapperTest extends TestCase
 {
@@ -36,7 +40,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     public function testToJsonLineCoverageForBankAccount(): void
     {
-        $coverage = $this->getLineCoverageForBankAccount()->getData();
+        $coverage    = $this->getLineCoverageForBankAccount()->getData();
         $decodedJson = $this->getDecodedJsonForProcessedCodeCoverage($coverage);
 
         $this->assertEquals(
@@ -52,7 +56,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     public function testToJsonPathCoverageForBankAccount(): void
     {
-        $coverage = $this->getPathCoverageForBankAccount()->getData();
+        $coverage    = $this->getPathCoverageForBankAccount()->getData();
         $decodedJson = $this->getDecodedJsonForProcessedCodeCoverage($coverage);
 
         $this->assertEquals(
@@ -68,7 +72,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     public function testFromJsonCoverageForBankAccount(): void
     {
-        $coverage = $this->getPathCoverageForBankAccount()->getData();
+        $coverage             = $this->getPathCoverageForBankAccount()->getData();
         $unserializedCoverage = $this->serializeAndUnserializeToJson($coverage);
 
         $this->assertEquals(
@@ -84,7 +88,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     public function testFromJsonPathCoverageForBankAccount(): void
     {
-        $coverage = $this->getPathCoverageForBankAccount()->getData();
+        $coverage             = $this->getPathCoverageForBankAccount()->getData();
         $unserializedCoverage = $this->serializeAndUnserializeToJson($coverage);
 
         $this->assertEquals(
@@ -99,13 +103,13 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
     }
 
     /**
-    * I don't expect this test to survive in the PR, but I am trying to 
-    * produce the final XML format via the JSON serialization to ensure
-    * that I have everything I need in the JSON format.
-    */
+     * I don't expect this test to survive in the PR, but I am trying to
+     * produce the final XML format via the JSON serialization to ensure
+     * that I have everything I need in the JSON format.
+     */
     public function testFromJsonLineCoverageForBankAccountToXml(): void
     {
-        $coverage = $this->getLineCoverageForBankAccount();
+        $coverage             = $this->getLineCoverageForBankAccount();
         $unserializedCoverage = $this->serializeAndUnserializeToJson($coverage->getData());
         $coverage->setData($unserializedCoverage);
 
@@ -119,24 +123,24 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
     private function getDecodedJsonForProcessedCodeCoverage(ProcessedCodeCoverageData $processedCodeCoverage): array
     {
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $json = $dataMapper->toJson($processedCodeCoverage);
+        $dataMapper = new ProcessedCodeCoverageDataMapper;
+        $json       = $dataMapper->toJson($processedCodeCoverage);
 
         return json_decode($json, true);
     }
 
     /**
-    * Doing it this way while the JSON format is being developed, though I expect we'd have a
-    * fixture file in the future
-    **/
+     * Doing it this way while the JSON format is being developed, though I expect we'd have a
+     * fixture file in the future.
+     */
     private function serializeAndUnserializeToJson(ProcessedCodeCoverageData $processedCodeCoverage): ProcessedCodeCoverageData
     {
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
-        $json = $dataMapper->toJson($processedCodeCoverage);
+        $dataMapper = new ProcessedCodeCoverageDataMapper;
+        $json       = $dataMapper->toJson($processedCodeCoverage);
 
-        // Instantiate a new data mapper out of an abundance of caution to ensure we have no 
+        // Instantiate a new data mapper out of an abundance of caution to ensure we have no
         // persisted state from the serializing instance.
-        $dataMapper = new ProcessedCodeCoverageDataMapper();
+        $dataMapper = new ProcessedCodeCoverageDataMapper;
 
         return $dataMapper->fromJson($json);
     }
@@ -168,4 +172,3 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
         }
     }
 }
-

--- a/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
+++ b/tests/tests/Data/ProcessedCodeCoverageDataMapperTest.php
@@ -23,7 +23,7 @@ final class ProcessedCodeCoverageDataMapperTest extends TestCase
 
         $this->assertEquals(
             $coverage->lineCoverage(),
-            $decodedJson['line_coverage'],
+            $decodedJson[ProcessedCodeCoverageDataMapper::KEY_LINE_COVERAGE],
         );
     }
 


### PR DESCRIPTION
This is my first pass at implementation for an object `SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageDataMapper` which serializes to JSON and de-serializes from JSON a given instance of `SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverage`.

The intention here is to move in the direction of being able to generate code coverage reports that do not require the serialize() and unserialize() PHP functions, and instead rely on a data only JSON format which might be less prone to issues such as https://github.com/sebastianbergmann/phpcov/issues/109. This PR attempts to implement a basic JSON format only, and does not fully realize that goal by replacing the current implementation of serialization or documentation.

The JSON format have essentially represents the underlying data in the class. i.e.

```javascript
{
   "lineCoverage": [
       // ...
   ],
   "functionCoverage": [
       // ...      
   ],
}
```

I have not attempted to include any of the meta data that might be used to instantiate a `Driver` or `Filter` instance which are required to instantiate a `CodeCoverage` instance.

* My Hesitations About My Implementation

I'm not sure if it would be better to make the JSON format more general, and nest the above properties under something like `coverage` using other keys, perhaps `driver` and `filter` or something else to include other meta data about the code coverage report. I have omitted this based on your stated preference to de-serialize to `ProcessedCodeCoverageReport`. I would welcome your guidance here.
   
 * My Hesitations About My Tests
 
I'm still familiarizing myself with the codebase and the shape of the coverage data, so I'm not certain I've covered everything I need to in testing.
 
I've included one "End to End" style test for XML which may not be appropriate to merge. This was more about me ensuring that I had everything I needed to replicate a known expected XML report. I'm not sure how far to go down this path in adding more tests like that, as it may be redundant, and I don't want to be retesting the XML report generation implementation. Once again, I'd welcome your opinion here.