### PR TITLE
Fix: Pad lines in code coverage report only when colors are shown

### DIFF
--- a/src/Report/Text.php
+++ b/src/Report/Text.php
@@ -10,9 +10,13 @@
 namespace SebastianBergmann\CodeCoverage\Report;
 
 use const PHP_EOL;
+use function array_map;
 use function date;
 use function ksort;
+use function max;
 use function sprintf;
+use function str_pad;
+use function strlen;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Node\File;
 use SebastianBergmann\CodeCoverage\Util\Percentage;
@@ -156,28 +160,31 @@ final class Text
             $report->numberOfExecutableLines(),
         );
 
-        if ($this->showOnlySummary) {
-            $title = 'Code Coverage Report Summary:';
+        $padding = max(array_map('strlen', [$classes, $methods, $lines]));
 
-            $output .= $this->format($colors['header'], $title);
+        if ($this->showOnlySummary) {
+            $title   = 'Code Coverage Report Summary:';
+            $padding = max($padding, strlen($title));
+
+            $output .= $this->format($colors['header'], $padding, $title);
         } else {
             $date  = date('  Y-m-d H:i:s');
             $title = 'Code Coverage Report:';
 
-            $output .= $this->format($colors['header'], $title);
-            $output .= $this->format($colors['header'], $date);
-            $output .= $this->format($colors['header'], '');
-            $output .= $this->format($colors['header'], ' Summary:');
+            $output .= $this->format($colors['header'], $padding, $title);
+            $output .= $this->format($colors['header'], $padding, $date);
+            $output .= $this->format($colors['header'], $padding, '');
+            $output .= $this->format($colors['header'], $padding, ' Summary:');
         }
 
-        $output .= $this->format($colors['classes'], $classes);
-        $output .= $this->format($colors['methods'], $methods);
+        $output .= $this->format($colors['classes'], $padding, $classes);
+        $output .= $this->format($colors['methods'], $padding, $methods);
 
         if ($hasBranchCoverage) {
-            $output .= $this->format($colors['paths'], $paths);
-            $output .= $this->format($colors['branches'], $branches);
+            $output .= $this->format($colors['paths'], $padding, $paths);
+            $output .= $this->format($colors['branches'], $padding, $branches);
         }
-        $output .= $this->format($colors['lines'], $lines);
+        $output .= $this->format($colors['lines'], $padding, $lines);
 
         if ($this->showOnlySummary) {
             return $output . PHP_EOL;
@@ -297,10 +304,12 @@ final class Text
         sprintf($format, $totalNumberOfElements) . ')';
     }
 
-    private function format(string $color, false|string $string): string
+    private function format(string $color, int $padding, false|string $string): string
     {
-        $reset = $color ? self::COLOR_RESET : '';
+        if ($color === '') {
+            return (string) $string . PHP_EOL;
+        }
 
-        return $color . (string) $string . $reset . PHP_EOL;
+        return $color . str_pad((string) $string, $padding) . self::COLOR_RESET . PHP_EOL;
     }
 }

--- a/src/Report/Text.php
+++ b/src/Report/Text.php
@@ -10,13 +10,9 @@
 namespace SebastianBergmann\CodeCoverage\Report;
 
 use const PHP_EOL;
-use function array_map;
 use function date;
 use function ksort;
-use function max;
 use function sprintf;
-use function str_pad;
-use function strlen;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Node\File;
 use SebastianBergmann\CodeCoverage\Util\Percentage;
@@ -160,31 +156,28 @@ final class Text
             $report->numberOfExecutableLines(),
         );
 
-        $padding = max(array_map('strlen', [$classes, $methods, $lines]));
-
         if ($this->showOnlySummary) {
-            $title   = 'Code Coverage Report Summary:';
-            $padding = max($padding, strlen($title));
+            $title = 'Code Coverage Report Summary:';
 
-            $output .= $this->format($colors['header'], $padding, $title);
+            $output .= $this->format($colors['header'], $title);
         } else {
             $date  = date('  Y-m-d H:i:s');
             $title = 'Code Coverage Report:';
 
-            $output .= $this->format($colors['header'], $padding, $title);
-            $output .= $this->format($colors['header'], $padding, $date);
-            $output .= $this->format($colors['header'], $padding, '');
-            $output .= $this->format($colors['header'], $padding, ' Summary:');
+            $output .= $this->format($colors['header'], $title);
+            $output .= $this->format($colors['header'], $date);
+            $output .= $this->format($colors['header'], '');
+            $output .= $this->format($colors['header'], ' Summary:');
         }
 
-        $output .= $this->format($colors['classes'], $padding, $classes);
-        $output .= $this->format($colors['methods'], $padding, $methods);
+        $output .= $this->format($colors['classes'], $classes);
+        $output .= $this->format($colors['methods'], $methods);
 
         if ($hasBranchCoverage) {
-            $output .= $this->format($colors['paths'], $padding, $paths);
-            $output .= $this->format($colors['branches'], $padding, $branches);
+            $output .= $this->format($colors['paths'], $paths);
+            $output .= $this->format($colors['branches'], $branches);
         }
-        $output .= $this->format($colors['lines'], $padding, $lines);
+        $output .= $this->format($colors['lines'], $lines);
 
         if ($this->showOnlySummary) {
             return $output . PHP_EOL;
@@ -304,10 +297,10 @@ final class Text
         sprintf($format, $totalNumberOfElements) . ')';
     }
 
-    private function format(string $color, int $padding, false|string $string): string
+    private function format(string $color, false|string $string): string
     {
         $reset = $color ? self::COLOR_RESET : '';
 
-        return $color . str_pad((string) $string, $padding) . $reset . PHP_EOL;
+        return $color . (string) $string . $reset . PHP_EOL;
     }
 }

--- a/tests/_files/BankAccount-text-line.txt
+++ b/tests/_files/BankAccount-text-line.txt
@@ -1,9 +1,9 @@
 
 
-Code Coverage Report:  
+Code Coverage Report:
   %s
-                       
- Summary:              
+
+ Summary:
   Classes:  0.00% (0/1)
   Methods: 75.00% (3/4)
   Lines:   62.50% (5/8)

--- a/tests/_files/BankAccount-text-path.txt
+++ b/tests/_files/BankAccount-text-path.txt
@@ -1,9 +1,9 @@
 
 
-Code Coverage Report:  
+Code Coverage Report:
   %s
-                       
- Summary:              
+
+ Summary:
   Classes:  0.00% (0/1)
   Methods: 75.00% (3/4)
   Paths:   60.00% (3/5)

--- a/tests/_files/BankAccount-text-summary.txt
+++ b/tests/_files/BankAccount-text-summary.txt
@@ -1,7 +1,7 @@
 
 
 Code Coverage Report Summary:
-  Classes:  0.00% (0/1)      
-  Methods: 75.00% (3/4)      
-  Lines:   62.50% (5/8)      
+  Classes:  0.00% (0/1)
+  Methods: 75.00% (3/4)
+  Lines:   62.50% (5/8)
 

--- a/tests/_files/BankAccountWithUncovered-text-line.txt
+++ b/tests/_files/BankAccountWithUncovered-text-line.txt
@@ -1,11 +1,11 @@
 
 
-Code Coverage Report:   
+Code Coverage Report:
   %s
-                        
- Summary:               
-  Classes:  0.00% (0/2) 
-  Methods: 37.50% (3/8) 
+
+ Summary:
+  Classes:  0.00% (0/2)
+  Methods: 37.50% (3/8)
   Lines:   31.25% (5/16)
 
 BankAccount

--- a/tests/_files/BankAccountWithoutUncovered-text-line.txt
+++ b/tests/_files/BankAccountWithoutUncovered-text-line.txt
@@ -1,9 +1,9 @@
 
 
-Code Coverage Report:  
+Code Coverage Report:
   %s
-                       
- Summary:              
+
+ Summary:
   Classes:  0.00% (0/1)
   Methods: 75.00% (3/4)
   Lines:   62.50% (5/8)

--- a/tests/_files/NamespacedBankAccount-text-with-colors.txt
+++ b/tests/_files/NamespacedBankAccount-text-with-colors.txt
@@ -1,0 +1,14 @@
+
+
+[1;37;40mCode Coverage Report:  [0m
+[1;37;40m  %s  [0m
+[1;37;40m                       [0m
+[1;37;40m Summary:              [0m
+[37;41m  Classes:  0.00% (0/1)[0m
+[30;43m  Methods: 75.00% (3/4)[0m
+[30;43m  Lines:   62.50% (5/8)[0m
+
+SomeNamespace\BankAccount
+  [30;42mMethods:  ( 0/ 0)[0m   [30;42mLines:  (  0/  0)[0m
+SomeNamespace\BankAccountTrait
+  [30;43mMethods:  75.00% ( 3/ 4)[0m   [30;43mLines:  62.50% (  5/  8)[0m

--- a/tests/_files/NamespacedBankAccount-text.txt
+++ b/tests/_files/NamespacedBankAccount-text.txt
@@ -1,9 +1,9 @@
 
 
-Code Coverage Report:  
+Code Coverage Report:
   %s
-                       
- Summary:              
+
+ Summary:
   Classes:  0.00% (0/1)
   Methods: 75.00% (3/4)
   Lines:   62.50% (5/8)

--- a/tests/_files/class-with-anonymous-function-text.txt
+++ b/tests/_files/class-with-anonymous-function-text.txt
@@ -1,9 +1,9 @@
 
 
-Code Coverage Report:   
+Code Coverage Report:
   %s
-                        
- Summary:               
+
+ Summary:
   Classes: 100.00% (1/1)
   Methods: 100.00% (1/1)
   Lines:   100.00% (8/8)

--- a/tests/_files/ignored-lines-text.txt
+++ b/tests/_files/ignored-lines-text.txt
@@ -1,10 +1,10 @@
 
 
-Code Coverage Report:%w
+Code Coverage Report:
   %s
-%w
- Summary:%w
-  Classes:        (0/0) 
-  Methods:        (0/0) 
+
+ Summary:
+  Classes:        (0/0)
+  Methods:        (0/0)
   Lines:   100.00% (1/1)
 

--- a/tests/tests/Report/TextTest.php
+++ b/tests/tests/Report/TextTest.php
@@ -57,6 +57,16 @@ final class TextTest extends TestCase
         );
     }
 
+    public function testTextForNamespacedBankAccountTestWhenColorsAreEnabled(): void
+    {
+        $text = new Text(Thresholds::default(), true, false);
+
+        $this->assertStringMatchesFormatFile(
+            TEST_FILES_PATH . 'NamespacedBankAccount-text-with-colors.txt',
+            str_replace(PHP_EOL, "\n", $text->process($this->getLineCoverageForNamespacedBankAccount(), true)),
+        );
+    }
+
     public function testTextForFileWithIgnoredLines(): void
     {
         $text = new Text(Thresholds::default(), false, false);


### PR DESCRIPTION
This pull request

- [x] pads lines in code coverage report only when colors are shown