### PR TITLE
Fix: Adjust `COMPOSER_ROOT_VERSION` and branch alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
 
 name: CI
 
-env:
-  COMPOSER_ROOT_VERSION: "9.2-dev"
-
 jobs:
   coding-guidelines:
     name: Coding Guidelines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: CI
 
+env:
+  COMPOSER_ROOT_VERSION: "9.2.x-dev"
+
 jobs:
   coding-guidelines:
     name: Coding Guidelines

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "9.2-dev"
+            "dev-main": "9.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
This pull request

- [x] removes the declaration of the `COMPOSER_ROOT_VERSION` environment variable

Related to #1038.