### PR TITLE
Add branch coverage stats to xml report

### DIFF
--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -252,6 +252,11 @@ final class Facade
             $node->numberOfExecutedLines(),
         );
 
+        $totals->setNumBranches(
+            $node->numberOfExecutableBranches(),
+            $node->numberOfExecutedBranches(),
+        );
+
         $totals->setNumClasses(
             $node->numberOfClasses(),
             $node->numberOfTestedClasses(),

--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -257,6 +257,11 @@ final class Facade
             $node->numberOfExecutedBranches(),
         );
 
+        $totals->setNumPaths(
+            $node->numberOfExecutablePaths(),
+            $node->numberOfExecutedPaths(),
+        );
+
         $totals->setNumClasses(
             $node->numberOfClasses(),
             $node->numberOfTestedClasses(),

--- a/src/Report/Xml/Totals.php
+++ b/src/Report/Xml/Totals.php
@@ -22,6 +22,7 @@ final readonly class Totals
     private DOMNode $container;
     private DOMElement $linesNode;
     private DOMElement $branchesNode;
+    private DOMElement $pathsNode;
     private DOMElement $methodsNode;
     private DOMElement $functionsNode;
     private DOMElement $classesNode;
@@ -40,6 +41,11 @@ final readonly class Totals
         $this->branchesNode = $dom->createElementNS(
             'https://schema.phpunit.de/coverage/1.0',
             'branches',
+        );
+
+        $this->pathsNode = $dom->createElementNS(
+            'https://schema.phpunit.de/coverage/1.0',
+            'paths',
         );
 
         $this->methodsNode = $dom->createElementNS(
@@ -64,6 +70,7 @@ final readonly class Totals
 
         $container->appendChild($this->linesNode);
         $container->appendChild($this->branchesNode);
+        $container->appendChild($this->pathsNode);
         $container->appendChild($this->methodsNode);
         $container->appendChild($this->functionsNode);
         $container->appendChild($this->classesNode);
@@ -93,6 +100,16 @@ final readonly class Totals
         $this->branchesNode->setAttribute('count', (string) $count);
         $this->branchesNode->setAttribute('tested', (string) $tested);
         $this->branchesNode->setAttribute(
+            'percent',
+            $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
+        );
+    }
+
+    public function setNumPaths(int $count, int $tested): void
+    {
+        $this->pathsNode->setAttribute('count', (string) $count);
+        $this->pathsNode->setAttribute('tested', (string) $tested);
+        $this->pathsNode->setAttribute(
             'percent',
             $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
         );

--- a/src/Report/Xml/Totals.php
+++ b/src/Report/Xml/Totals.php
@@ -21,6 +21,7 @@ final readonly class Totals
 {
     private DOMNode $container;
     private DOMElement $linesNode;
+    private DOMElement $branchesNode;
     private DOMElement $methodsNode;
     private DOMElement $functionsNode;
     private DOMElement $classesNode;
@@ -34,6 +35,11 @@ final readonly class Totals
         $this->linesNode = $dom->createElementNS(
             'https://schema.phpunit.de/coverage/1.0',
             'lines',
+        );
+
+        $this->branchesNode = $dom->createElementNS(
+            'https://schema.phpunit.de/coverage/1.0',
+            'branches',
         );
 
         $this->methodsNode = $dom->createElementNS(
@@ -57,6 +63,7 @@ final readonly class Totals
         );
 
         $container->appendChild($this->linesNode);
+        $container->appendChild($this->branchesNode);
         $container->appendChild($this->methodsNode);
         $container->appendChild($this->functionsNode);
         $container->appendChild($this->classesNode);
@@ -78,6 +85,16 @@ final readonly class Totals
         $this->linesNode->setAttribute(
             'percent',
             $executable === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($executed, $executable)->asFloat()),
+        );
+    }
+
+    public function setNumBranches(int $count, int $tested): void
+    {
+        $this->branchesNode->setAttribute('count', (string) $count);
+        $this->branchesNode->setAttribute('tested', (string) $tested);
+        $this->branchesNode->setAttribute(
+            'percent',
+            $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
         );
     }
 

--- a/tests/_files/Report/XML/CoverageForBankAccount/BankAccount.php.xml
+++ b/tests/_files/Report/XML/CoverageForBankAccount/BankAccount.php.xml
@@ -4,6 +4,7 @@
     <totals>
       <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
       <branches count="0" tested="0" percent="0"/>
+      <paths count="0" tested="0" percent="0"/>
       <methods count="4" tested="3" percent="75.00"/>
       <functions count="0" tested="0" percent="0"/>
       <classes count="1" tested="0" percent="0.00"/>

--- a/tests/_files/Report/XML/CoverageForBankAccount/index.xml
+++ b/tests/_files/Report/XML/CoverageForBankAccount/index.xml
@@ -15,6 +15,7 @@
       <totals>
         <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
         <branches count="0" tested="0" percent="0"/>
+        <paths count="0" tested="0" percent="0"/>
         <methods count="4" tested="3" percent="75.00"/>
         <functions count="0" tested="0" percent="0"/>
         <classes count="1" tested="0" percent="0.00"/>
@@ -24,6 +25,7 @@
         <totals>
           <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
           <branches count="0" tested="0" percent="0"/>
+          <paths count="0" tested="0" percent="0"/>
           <methods count="4" tested="3" percent="75.00"/>
           <functions count="0" tested="0" percent="0"/>
           <classes count="1" tested="0" percent="0.00"/>

--- a/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/index.xml
+++ b/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/index.xml
@@ -12,6 +12,7 @@
       <totals>
         <lines total="20" comments="1" code="19" executable="8" executed="8" percent="100.00"/>
         <branches count="0" tested="0" percent="0"/>
+        <paths count="0" tested="0" percent="0"/>
         <methods count="1" tested="1" percent="100.00"/>
         <functions count="0" tested="0" percent="0"/>
         <classes count="1" tested="1" percent="100.00"/>
@@ -21,6 +22,7 @@
         <totals>
           <lines total="20" comments="1" code="19" executable="8" executed="8" percent="100.00"/>
           <branches count="0" tested="0" percent="0"/>
+          <paths count="0" tested="0" percent="0"/>
           <methods count="1" tested="1" percent="100.00"/>
           <functions count="0" tested="0" percent="0"/>
           <classes count="1" tested="1" percent="100.00"/>

--- a/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/index.xml
+++ b/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/index.xml
@@ -11,6 +11,7 @@
     <directory name="%s">
       <totals>
         <lines total="20" comments="1" code="19" executable="8" executed="8" percent="100.00"/>
+        <branches count="0" tested="0" percent="0"/>
         <methods count="1" tested="1" percent="100.00"/>
         <functions count="0" tested="0" percent="0"/>
         <classes count="1" tested="1" percent="100.00"/>
@@ -19,6 +20,7 @@
       <file name="source_with_class_and_anonymous_function.php" href="source_with_class_and_anonymous_function.php.xml">
         <totals>
           <lines total="20" comments="1" code="19" executable="8" executed="8" percent="100.00"/>
+          <branches count="0" tested="0" percent="0"/>
           <methods count="1" tested="1" percent="100.00"/>
           <functions count="0" tested="0" percent="0"/>
           <classes count="1" tested="1" percent="100.00"/>

--- a/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.xml
+++ b/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.xml
@@ -4,6 +4,7 @@
     <totals>
       <lines total="20" comments="1" code="19" executable="8" executed="8" percent="100.00"/>
       <branches count="0" tested="0" percent="0"/>
+      <paths count="0" tested="0" percent="0"/>
       <methods count="1" tested="1" percent="100.00"/>
       <functions count="0" tested="0" percent="0"/>
       <classes count="1" tested="1" percent="100.00"/>

--- a/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.xml
+++ b/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.xml
@@ -3,6 +3,7 @@
   <file name="source_with_class_and_anonymous_function.php" path="%e">
     <totals>
       <lines total="20" comments="1" code="19" executable="8" executed="8" percent="100.00"/>
+      <branches count="0" tested="0" percent="0"/>
       <methods count="1" tested="1" percent="100.00"/>
       <functions count="0" tested="0" percent="0"/>
       <classes count="1" tested="1" percent="100.00"/>

--- a/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/index.xml
+++ b/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/index.xml
@@ -11,6 +11,7 @@
     <directory name="%s">
       <totals>
         <lines total="43" comments="11" code="32" executable="1" executed="1" percent="100.00"/>
+        <branches count="0" tested="0" percent="0"/>
         <methods count="0" tested="0" percent="0"/>
         <functions count="1" tested="1" percent="100.00"/>
         <classes count="0" tested="0" percent="0"/>
@@ -19,6 +20,7 @@
       <file name="source_with_ignore.php" href="source_with_ignore.php.xml">
         <totals>
           <lines total="43" comments="11" code="32" executable="1" executed="1" percent="100.00"/>
+          <branches count="0" tested="0" percent="0"/>
           <methods count="0" tested="0" percent="0"/>
           <functions count="1" tested="1" percent="100.00"/>
           <classes count="0" tested="0" percent="0"/>

--- a/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/index.xml
+++ b/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/index.xml
@@ -12,6 +12,7 @@
       <totals>
         <lines total="43" comments="11" code="32" executable="1" executed="1" percent="100.00"/>
         <branches count="0" tested="0" percent="0"/>
+        <paths count="0" tested="0" percent="0"/>
         <methods count="0" tested="0" percent="0"/>
         <functions count="1" tested="1" percent="100.00"/>
         <classes count="0" tested="0" percent="0"/>
@@ -21,6 +22,7 @@
         <totals>
           <lines total="43" comments="11" code="32" executable="1" executed="1" percent="100.00"/>
           <branches count="0" tested="0" percent="0"/>
+          <paths count="0" tested="0" percent="0"/>
           <methods count="0" tested="0" percent="0"/>
           <functions count="1" tested="1" percent="100.00"/>
           <classes count="0" tested="0" percent="0"/>

--- a/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/source_with_ignore.php.xml
+++ b/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/source_with_ignore.php.xml
@@ -3,6 +3,7 @@
   <file name="source_with_ignore.php" path="%e">
     <totals>
       <lines total="43" comments="11" code="32" executable="1" executed="1" percent="100.00"/>
+      <branches count="0" tested="0" percent="0"/>
       <methods count="0" tested="0" percent="0"/>
       <functions count="1" tested="1" percent="100.00"/>
       <classes count="0" tested="0" percent="0"/>

--- a/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/source_with_ignore.php.xml
+++ b/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/source_with_ignore.php.xml
@@ -4,6 +4,7 @@
     <totals>
       <lines total="43" comments="11" code="32" executable="1" executed="1" percent="100.00"/>
       <branches count="0" tested="0" percent="0"/>
+      <paths count="0" tested="0" percent="0"/>
       <methods count="0" tested="0" percent="0"/>
       <functions count="1" tested="1" percent="100.00"/>
       <classes count="0" tested="0" percent="0"/>

--- a/tests/_files/Report/XML/PathCoverageForBankAccount/BankAccount.php.xml
+++ b/tests/_files/Report/XML/PathCoverageForBankAccount/BankAccount.php.xml
@@ -3,13 +3,13 @@
   <file name="BankAccount.php" path="%e">
     <totals>
       <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
-      <branches count="0" tested="0" percent="0"/>
+      <branches count="7" tested="3" percent="42.86"/>
       <methods count="4" tested="3" percent="75.00"/>
       <functions count="0" tested="0" percent="0"/>
       <classes count="1" tested="0" percent="0.00"/>
       <traits count="0" tested="0" percent="0"/>
     </totals>
-    <class name="BankAccount" start="2" executable="8" executed="5" crap="6.32">
+    <class name="BankAccount" start="2" executable="8" executed="5" crap="6.6">
       <namespace name=""/>
       <method name="getBalance" signature="getBalance()" start="6" end="9" crap="1" executable="1" executed="1" coverage="100"/>
       <method name="setBalance" signature="setBalance($balance)" start="11" end="18" crap="6" executable="3" executed="0" coverage="0"/>

--- a/tests/_files/Report/XML/PathCoverageForBankAccount/BankAccount.php.xml
+++ b/tests/_files/Report/XML/PathCoverageForBankAccount/BankAccount.php.xml
@@ -4,6 +4,7 @@
     <totals>
       <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
       <branches count="7" tested="3" percent="42.86"/>
+      <paths count="5" tested="3" percent="60.00"/>
       <methods count="4" tested="3" percent="75.00"/>
       <functions count="0" tested="0" percent="0"/>
       <classes count="1" tested="0" percent="0.00"/>

--- a/tests/_files/Report/XML/PathCoverageForBankAccount/index.xml
+++ b/tests/_files/Report/XML/PathCoverageForBankAccount/index.xml
@@ -14,7 +14,7 @@
     <directory name="%s">
       <totals>
         <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
-        <branches count="0" tested="0" percent="0"/>
+        <branches count="7" tested="3" percent="42.86"/>
         <methods count="4" tested="3" percent="75.00"/>
         <functions count="0" tested="0" percent="0"/>
         <classes count="1" tested="0" percent="0.00"/>
@@ -23,7 +23,7 @@
       <file name="BankAccount.php" href="BankAccount.php.xml">
         <totals>
           <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
-          <branches count="0" tested="0" percent="0"/>
+          <branches count="7" tested="3" percent="42.86"/>
           <methods count="4" tested="3" percent="75.00"/>
           <functions count="0" tested="0" percent="0"/>
           <classes count="1" tested="0" percent="0.00"/>

--- a/tests/_files/Report/XML/PathCoverageForBankAccount/index.xml
+++ b/tests/_files/Report/XML/PathCoverageForBankAccount/index.xml
@@ -15,6 +15,7 @@
       <totals>
         <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
         <branches count="7" tested="3" percent="42.86"/>
+        <paths count="5" tested="3" percent="60.00"/>
         <methods count="4" tested="3" percent="75.00"/>
         <functions count="0" tested="0" percent="0"/>
         <classes count="1" tested="0" percent="0.00"/>
@@ -24,6 +25,7 @@
         <totals>
           <lines total="35" comments="0" code="35" executable="8" executed="5" percent="62.50"/>
           <branches count="7" tested="3" percent="42.86"/>
+          <paths count="5" tested="3" percent="60.00"/>
           <methods count="4" tested="3" percent="75.00"/>
           <functions count="0" tested="0" percent="0"/>
           <classes count="1" tested="0" percent="0.00"/>

--- a/tests/tests/Report/XmlTest.php
+++ b/tests/tests/Report/XmlTest.php
@@ -67,6 +67,16 @@ final class XmlTest extends TestCase
         $this->assertFilesEquals($expectedFilesPath, TEST_FILES_PATH . 'tmp');
     }
 
+    public function testForBankAccountWithPathCoverage(): void
+    {
+        $expectedFilesPath = self::$TEST_REPORT_PATH_SOURCE . DIRECTORY_SEPARATOR . 'PathCoverageForBankAccount';
+
+        $xml = new Facade('1.0.0');
+        $xml->process($this->getPathCoverageForBankAccount(), TEST_FILES_PATH . 'tmp');
+
+        $this->assertFilesEquals($expectedFilesPath, TEST_FILES_PATH . 'tmp');
+    }
+
     private function assertFilesEquals(string $expectedFilesPath, string $actualFilesPath): void
     {
         $expectedFilesIterator = new FilesystemIterator($expectedFilesPath);


### PR DESCRIPTION
Added new <branches> and <paths> elements under the <totals> element, and populated attributes appropriately. If path coverage is not enabled, the `count`, `tested` and `percent` attributes will all be set to `0`.

I could not find a schema for the XML report to update / validate against (navigating to https://schema.phpunit.de/coverage/1.0 resulted in a 404 error).

Implements enhancement suggested in #1056. 