### PR TITLE
Use more efficient AttributeParentConnectingVisitor

### DIFF
--- a/src/StaticAnalysis/AttributeParentConnectingVisitor.php
+++ b/src/StaticAnalysis/AttributeParentConnectingVisitor.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\StaticAnalysis;
+
+use function array_pop;
+use function count;
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+
+/**
+ * Visitor that connects a child node to its parent node optimzed for Attribute nodes.
+ *
+ * On the child node, the parent node can be accessed through
+ * <code>$node->getAttribute('parent')</code>.
+ */
+final class AttributeParentConnectingVisitor implements NodeVisitor
+{
+    /**
+     * @var Node[]
+     */
+    private array $stack = [];
+
+    public function beforeTraverse(array $nodes): null
+    {
+        $this->stack = [];
+
+        return null;
+    }
+
+    public function enterNode(Node $node): null
+    {
+        if (
+            $this->stack !== [] &&
+            ($node instanceof Node\Attribute || $node instanceof Node\AttributeGroup)
+        ) {
+            $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
+        }
+
+        $this->stack[] = $node;
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): null
+    {
+        array_pop($this->stack);
+
+        return null;
+    }
+
+    public function afterTraverse(array $nodes): null
+    {
+        return null;
+    }
+}

--- a/src/StaticAnalysis/ParsingFileAnalyser.php
+++ b/src/StaticAnalysis/ParsingFileAnalyser.php
@@ -26,7 +26,6 @@ use function trim;
 use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
-use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\ParserFactory;
 use SebastianBergmann\CodeCoverage\ParserException;
 use SebastianBergmann\LinesOfCode\LineCountingVisitor;
@@ -180,7 +179,7 @@ final class ParsingFileAnalyser implements FileAnalyser
             $executableLinesFindingVisitor = new ExecutableLinesFindingVisitor($source);
 
             $traverser->addVisitor(new NameResolver);
-            $traverser->addVisitor(new ParentConnectingVisitor);
+            $traverser->addVisitor(new AttributeParentConnectingVisitor);
             $traverser->addVisitor($codeUnitFindingVisitor);
             $traverser->addVisitor($lineCountingVisitor);
             $traverser->addVisitor($ignoredLinesFindingVisitor);


### PR DESCRIPTION
1:1 copy of php-parsers ParentConnectingVisitor but optimized for our use-case

after PR
```
➜  php-code-coverage git:(attr-paren) ✗ hyperfine --prepare 'rm -rf /tmp/coverage-cache' 'php test.php'
Benchmark 1: php test.php
  Time (mean ± σ):     159.4 ms ±   1.2 ms    [User: 137.7 ms, System: 18.9 ms]
  Range (min … max):   156.2 ms … 161.1 ms    18 runs
```

before PR
``` 
➜  php-code-coverage git:(attr-paren) ✗ hyperfine --prepare 'rm -rf /tmp/coverage-cache' 'php test.php'
Benchmark 1: php test.php
  Time (mean ± σ):     163.0 ms ±   1.1 ms    [User: 140.1 ms, System: 19.9 ms]
  Range (min … max):   161.1 ms … 164.8 ms    17 runs
```

refs https://github.com/sebastianbergmann/php-code-coverage/issues/1072#issuecomment-2832263578

Less references between AST nodes mean less work for GC