### PR TITLE
Sort complexity results before encoding so that graph is properly populated

### DIFF
--- a/src/Report/Html/Renderer/Dashboard.php
+++ b/src/Report/Html/Renderer/Dashboard.php
@@ -116,6 +116,8 @@ final class Dashboard extends Renderer
             ];
         }
 
+        usort($result['class'], fn($a, $b) => intval($a[0] - $b[0]));
+
         $class = json_encode($result['class']);
 
         assert($class !== false);


### PR DESCRIPTION
In reference to this issue:

https://github.com/sebastianbergmann/php-code-coverage/issues/1081

This sorts the ordering