### PR TITLE
Move issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,3 +1,8 @@
+---
+name: Generic issue
+about: Use this template for all issues.
+---
+
 | Q                         | A
 | --------------------------| ---------------
 | php-code-coverage version | x.y.z

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
For unphanthomable reasons, GitHub, in their wisdom, have decided to remove support for single (default) issue templates.

In practice, this means that the issue template for this repo was no longer used.

To mitigate this, the template file needs to be moved to the `.github/ISSUE_TEMPLATE` subdirectory and YAML frontmatter must be added to the template for the template. This will also reinstate the issue template ✔ checkmark in the community profile checklist (Insights -> Community Standards).

However, doing this will now create an even more annoying problem: the "New Issue" button will now open the issue template chooser instead of just defaulting to the single issue template for the repo.

Unfortunately, this cannot be mitigated for repos which also have a security policy as the "Report a security vulnerability" item in the template chooser cannot be disabled.

The only thing which can be done to at least prevent end-users from bypassing the issue template, is to add a `config.yml` file to disable blank issues.

What can I say... :woman_shrugging: _sigh_

Refs:
* https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#%f0%9f%8c%85-single-issue-templates-issue_template-md-will-be-retired
* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository