### PR TITLE
Faster coverage-xml report

### DIFF
--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -165,12 +165,7 @@ final class Facade
             }
 
             $coverage = $fileReport->lineCoverage((string) $line);
-
-            foreach ($tests as $test) {
-                $coverage->addTest($test);
-            }
-
-            $coverage->finalize();
+            $coverage->finalize($tests);
         }
 
         $fileReport->source()->setSourceCode(


### PR DESCRIPTION
before this PR
```
➜  slow-coverage-xml1 git:(main) ✗ hyperfine 'php coverage-xml.php'
Benchmark 1: php coverage-xml.php
  Time (mean ± σ):     11.744 s ±  0.072 s    [User: 10.387 s, System: 1.305 s]
  Range (min … max):   11.641 s … 11.854 s    10 runs
```

after this PR
```
➜  slow-coverage-xml1 git:(main) ✗ hyperfine 'php coverage-xml.php'
Benchmark 1: php coverage-xml.php
  Time (mean ± σ):     11.594 s ±  0.073 s    [User: 10.266 s, System: 1.275 s]
  Range (min … max):   11.511 s … 11.762 s    10 runs
```

running [my benchmark based on phpstan-src codebase recorded coverage data](https://github.com/staabm/code-coverage-benchmarks/tree/89d601676d7fbb58dc693af71f3e7704f7a7787d/slow-coverage-xml1).

this change is based on the observation that the inlined `addTest` method is invoked ~10 million times, when running code-coverage even on a small portion of the phpstan-src codebase

` XDEBUG_MODE=coverage php tests/vendor/bin/paratest --coverage-xml=tmp/coverage-xml tests/PHPStan/Analyser`

<img width="620" height="224" alt="grafik" src="https://github.com/user-attachments/assets/89cfff1d-8a1b-41dc-8331-819620884c67" />
