### PR TITLE
Fix FunctionCoverageDataType

### DIFF
--- a/src/Data/ProcessedCodeCoverageData.php
+++ b/src/Data/ProcessedCodeCoverageData.php
@@ -38,8 +38,7 @@ use SebastianBergmann\CodeCoverage\Driver\XdebugDriver;
  *      paths: array<int, array{
  *          path: array<int, int>,
  *          hit: list<TestIdType>,
- *      }>,
- *      hit: list<TestIdType>
+ *      }>
  *  }
  * @phpstan-type FunctionCoverageType array<string, array<string, FunctionCoverageDataType>>
  */


### PR DESCRIPTION
From looking at the source I think `FunctionCoverageDataType` does not have a `hit` offset