### PR TITLE
Use plain `for`-loop over `foreach(range() ..)`

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -11,7 +11,6 @@ namespace SebastianBergmann\CodeCoverage\Node;
 
 use function array_filter;
 use function count;
-use function range;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\StaticAnalysis\AnalysisResult;
 use SebastianBergmann\CodeCoverage\StaticAnalysis\Class_;
@@ -372,7 +371,7 @@ final class File extends AbstractNode
      */
     private function calculateStatistics(array $classes, array $traits, array $functions): void
     {
-        foreach (range(1, $this->linesOfCode->linesOfCode()) as $lineNumber) {
+        for ($lineNumber = 1; $lineNumber <= $this->linesOfCode->linesOfCode(); $lineNumber++) {
             $this->codeUnitsByLine[$lineNumber] = [];
         }
 
@@ -380,7 +379,7 @@ final class File extends AbstractNode
         $this->processTraits($traits);
         $this->processFunctions($functions);
 
-        foreach (range(1, $this->linesOfCode->linesOfCode()) as $lineNumber) {
+        for ($lineNumber = 1; $lineNumber <= $this->linesOfCode->linesOfCode(); $lineNumber++) {
             if (isset($this->lineCoverageData[$lineNumber])) {
                 foreach ($this->codeUnitsByLine[$lineNumber] as &$codeUnit) {
                     $codeUnit['executableLines']++;
@@ -511,7 +510,7 @@ final class File extends AbstractNode
                 $this->numExecutablePaths    += $methodData['executablePaths'];
                 $this->numExecutedPaths      += $methodData['executedPaths'];
 
-                foreach (range($method->startLine(), $method->endLine()) as $lineNumber) {
+                for ($lineNumber = $method->startLine(); $lineNumber <= $method->endLine(); $lineNumber++) {
                     $this->codeUnitsByLine[$lineNumber] = [
                         &$this->classes[$className],
                         &$this->classes[$className]['methods'][$methodName],
@@ -560,7 +559,7 @@ final class File extends AbstractNode
                 $this->numExecutablePaths    += $methodData['executablePaths'];
                 $this->numExecutedPaths      += $methodData['executedPaths'];
 
-                foreach (range($method->startLine(), $method->endLine()) as $lineNumber) {
+                for ($lineNumber = $method->startLine(); $lineNumber <= $method->endLine(); $lineNumber++) {
                     $this->codeUnitsByLine[$lineNumber] = [
                         &$this->traits[$traitName],
                         &$this->traits[$traitName]['methods'][$methodName],
@@ -596,7 +595,7 @@ final class File extends AbstractNode
                 'link'               => $link . $function->startLine(),
             ];
 
-            foreach (range($function->startLine(), $function->endLine()) as $lineNumber) {
+            for ($lineNumber = $function->startLine(); $lineNumber <= $function->endLine(); $lineNumber++) {
                 $this->codeUnitsByLine[$lineNumber] = [&$this->functions[$functionName]];
             }
 

--- a/src/Report/Clover.php
+++ b/src/Report/Clover.php
@@ -13,7 +13,6 @@ use function count;
 use function is_string;
 use function ksort;
 use function max;
-use function range;
 use function time;
 use DOMDocument;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
@@ -95,7 +94,7 @@ final class Clover
 
                     $methodCount = 0;
 
-                    foreach (range($method['startLine'], $method['endLine']) as $line) {
+                    for ($line = $method['startLine']; $line <= $method['endLine']; $line++) {
                         if (isset($coverageData[$line])) {
                             $methodCount = max($methodCount, count($coverageData[$line]));
                         }

--- a/src/Report/Cobertura.php
+++ b/src/Report/Cobertura.php
@@ -13,7 +13,6 @@ use const DIRECTORY_SEPARATOR;
 use function basename;
 use function count;
 use function preg_match;
-use function range;
 use function str_replace;
 use function time;
 use DOMImplementation;
@@ -170,7 +169,7 @@ final class Cobertura
 
                     $methodElement->appendChild($methodLinesElement);
 
-                    foreach (range($method['startLine'], $method['endLine']) as $line) {
+                    for ($line = $method['startLine']; $line <= $method['endLine']; $line++) {
                         if (!isset($coverageData[$line])) {
                             continue;
                         }
@@ -251,7 +250,7 @@ final class Cobertura
 
                 $methodElement->appendChild($methodLinesElement);
 
-                foreach (range($function['startLine'], $function['endLine']) as $line) {
+                for ($line = $function['startLine']; $line <= $function['endLine']; $line++) {
                     if (!isset($coverageData[$line])) {
                         continue;
                     }

--- a/src/Report/Html/Renderer/File.php
+++ b/src/Report/Html/Renderer/File.php
@@ -609,7 +609,7 @@ final class File extends Renderer
 
         foreach ($functionCoverageData as $method) {
             foreach ($method['branches'] as $branch) {
-                foreach (range($branch['line_start'], $branch['line_end']) as $line) {
+                for ($line = $branch['line_start']; $line <= $branch['line_end']; $line++) {
                     if (!isset($lineData[$line])) { // blank line at end of file is sometimes included here
                         continue;
                     }
@@ -696,7 +696,7 @@ final class File extends Renderer
         foreach ($functionCoverageData as $method) {
             foreach ($method['paths'] as $pathId => $path) {
                 foreach ($path['path'] as $branchTaken) {
-                    foreach (range($method['branches'][$branchTaken]['line_start'], $method['branches'][$branchTaken]['line_end']) as $line) {
+                    for ($line = $method['branches'][$branchTaken]['line_start']; $line <= $method['branches'][$branchTaken]['line_end']; $line++) {
                         if (!isset($lineData[$line])) {
                             continue;
                         }

--- a/src/Report/OpenClover.php
+++ b/src/Report/OpenClover.php
@@ -15,7 +15,6 @@ use function count;
 use function is_string;
 use function ksort;
 use function max;
-use function range;
 use function str_replace;
 use function time;
 use DOMDocument;
@@ -99,7 +98,7 @@ final class OpenClover
 
                     $methodCount = 0;
 
-                    foreach (range($method['startLine'], $method['endLine']) as $line) {
+                    for ($line = $method['startLine']; $line <= $method['endLine']; $line++) {
                         if (isset($coverageData[$line])) {
                             $methodCount = max($methodCount, count($coverageData[$line]));
                         }

--- a/src/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php
@@ -18,7 +18,6 @@ use function explode;
 use function max;
 use function preg_match;
 use function preg_quote;
-use function range;
 use function reset;
 use function sprintf;
 use PhpParser\Node;
@@ -75,7 +74,7 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             $endLine   = $node->getEndLine() - 1;
 
             if ($startLine <= $endLine) {
-                foreach (range($startLine, $endLine) as $line) {
+                for ($line = $startLine; $line <= $endLine; $line++) {
                     unset($this->executableLinesGroupedByBranch[$line]);
                 }
             }
@@ -84,7 +83,7 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
         }
 
         if ($node instanceof Node\Stmt\Interface_) {
-            foreach (range($node->getStartLine(), $node->getEndLine()) as $line) {
+            for ($line = $node->getStartLine(); $line <= $node->getEndLine(); $line++) {
                 $this->unsets[$line] = true;
             }
 
@@ -144,7 +143,7 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
                 $unsets = [];
 
                 foreach ($node->getParams() as $param) {
-                    foreach (range($param->getStartLine(), $param->getEndLine()) as $line) {
+                    for ($line = $param->getStartLine(); $line <= $param->getEndLine(); $line++) {
                         $unsets[$line] = true;
                     }
                 }
@@ -162,7 +161,7 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
                         continue;
                     }
 
-                    foreach (range($stmt->getStartLine(), $stmt->getEndLine()) as $line) {
+                    for ($line = $stmt->getStartLine(); $line <= $stmt->getEndLine(); $line++) {
                         unset($this->executableLinesGroupedByBranch[$line]);
 
                         if (
@@ -395,7 +394,7 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
 
     private function setLineBranch(int $start, int $end, int $branch): void
     {
-        foreach (range($start, $end) as $line) {
+        for ($line = $start; $line <= $end; $line++) {
             $this->executableLinesGroupedByBranch[$line] = $branch;
         }
     }

--- a/src/Target/MapBuilder.php
+++ b/src/Target/MapBuilder.php
@@ -111,7 +111,7 @@ final readonly class MapBuilder
 
                 $this->process($functions, $function->namespacedName(), $file, $function->startLine(), $function->endLine());
 
-                foreach (range($function->startLine(), $function->endLine()) as $line) {
+                for ($line = $function->startLine(); $line <= $function->endLine(); $line++) {
                     $reverseLookup[$file . ':' . $line] = $function->namespacedName();
                 }
             }
@@ -202,7 +202,7 @@ final readonly class MapBuilder
 
             $this->process($methods, $methodName, $file, $method->startLine(), $method->endLine());
 
-            foreach (range($method->startLine(), $method->endLine()) as $line) {
+            for ($line = $method->startLine(); $line <= $method->endLine(); $line++) {
                 $reverseLookup[$file . ':' . $line] = $methodName;
             }
         }
@@ -221,7 +221,7 @@ final readonly class MapBuilder
     {
         $parts = explode('\\', $namespace);
 
-        foreach (range(1, count($parts)) as $i) {
+        for ($i = 1; $i <= count($parts); $i++) {
             $this->process($data, implode('\\', array_slice($parts, 0, $i)), $file, $startLine, $endLine);
         }
     }


### PR DESCRIPTION
`range()` is showing up in the top 5 memory consumers when running 

`XDEBUG_MODE=coverage blackfire run php vendor/bin/phpunit --coverage-xml=tmp/coverage-xml tests/PHPStan/Rules/Api/`

on phpstan-src

<img width="595" height="424" alt="grafik" src="https://github.com/user-attachments/assets/419b4692-05bb-428f-b5ae-4462c6b58d7e" />

---

PS: `token_get_all` will be more efficient with https://github.com/theseer/tokenizer/pull/35