### PR TITLE
Unit: Move always available information into __construct()

### DIFF
--- a/src/Report/Xml/Facade.php
+++ b/src/Report/Xml/Facade.php
@@ -182,19 +182,24 @@ final class Facade
     private function processUnit(array $unit, Report $report): void
     {
         if (isset($unit['className'])) {
-            $unitObject = $report->classObject($unit['className']);
+            $unitObject = $report->classObject(
+                $unit['className'],
+                $unit['namespace'],
+                $unit['startLine'],
+                $unit['executableLines'],
+                $unit['executedLines'],
+                (float) $unit['crap'],
+            );
         } else {
-            $unitObject = $report->traitObject($unit['traitName']);
+            $unitObject = $report->traitObject(
+                $unit['traitName'],
+                $unit['namespace'],
+                $unit['startLine'],
+                $unit['executableLines'],
+                $unit['executedLines'],
+                (float) $unit['crap'],
+            );
         }
-
-        $unitObject->setLines(
-            $unit['startLine'],
-            $unit['executableLines'],
-            $unit['executedLines'],
-        );
-
-        $unitObject->setCrap((float) $unit['crap']);
-        $unitObject->setNamespace($unit['namespace']);
 
         foreach ($unit['methods'] as $method) {
             $methodObject = $unitObject->addMethod($method['methodName']);

--- a/src/Report/Xml/Report.php
+++ b/src/Report/Xml/Report.php
@@ -59,14 +59,44 @@ final class Report extends File
         return new Method($node, $name);
     }
 
-    public function classObject(string $name): Unit
-    {
-        return $this->unitObject('class', $name);
+    public function classObject(
+        string $name,
+        string $namespace,
+        int $start,
+        int $executable,
+        int $executed,
+        float $crap
+    ): Unit {
+        $node = $this->contextNode()->appendChild(
+            $this->dom()->createElementNS(
+                Facade::XML_NAMESPACE,
+                'class',
+            ),
+        );
+
+        assert($node instanceof DOMElement);
+
+        return new Unit($node, $name, $namespace, $start, $executable, $executed, $crap);
     }
 
-    public function traitObject(string $name): Unit
-    {
-        return $this->unitObject('trait', $name);
+    public function traitObject(
+        string $name,
+        string $namespace,
+        int $start,
+        int $executable,
+        int $executed,
+        float $crap
+    ): Unit {
+        $node = $this->contextNode()->appendChild(
+            $this->dom()->createElementNS(
+                Facade::XML_NAMESPACE,
+                'trait',
+            ),
+        );
+
+        assert($node instanceof DOMElement);
+
+        return new Unit($node, $name, $namespace, $start, $executable, $executed, $crap);
     }
 
     public function source(): Source
@@ -88,19 +118,5 @@ final class Report extends File
         assert($source instanceof DOMElement);
 
         return new Source($source);
-    }
-
-    private function unitObject(string $tagName, string $name): Unit
-    {
-        $node = $this->contextNode()->appendChild(
-            $this->dom()->createElementNS(
-                Facade::XML_NAMESPACE,
-                $tagName,
-            ),
-        );
-
-        assert($node instanceof DOMElement);
-
-        return new Unit($node, $name);
     }
 }

--- a/src/Report/Xml/Unit.php
+++ b/src/Report/Xml/Unit.php
@@ -19,41 +19,29 @@ final readonly class Unit
 {
     private DOMElement $contextNode;
 
-    public function __construct(DOMElement $context, string $name)
-    {
+    public function __construct(
+        DOMElement $context,
+        string $name,
+        string $namespace,
+        int $start,
+        int $executable,
+        int $executed,
+        float $crap
+    ) {
         $this->contextNode = $context;
 
-        $this->setName($name);
-    }
-
-    public function setLines(int $start, int $executable, int $executed): void
-    {
+        $this->contextNode->setAttribute('name', $name);
         $this->contextNode->setAttribute('start', (string) $start);
         $this->contextNode->setAttribute('executable', (string) $executable);
         $this->contextNode->setAttribute('executed', (string) $executed);
-    }
-
-    public function setCrap(float $crap): void
-    {
         $this->contextNode->setAttribute('crap', (string) $crap);
-    }
 
-    public function setNamespace(string $namespace): void
-    {
-        $node = $this->contextNode->getElementsByTagNameNS(
-            Facade::XML_NAMESPACE,
-            'namespace',
-        )->item(0);
-
-        if ($node === null) {
-            $node = $this->contextNode->appendChild(
-                $this->contextNode->ownerDocument->createElementNS(
-                    Facade::XML_NAMESPACE,
-                    'namespace',
-                ),
-            );
-        }
-
+        $node = $this->contextNode->appendChild(
+            $this->contextNode->ownerDocument->createElementNS(
+                Facade::XML_NAMESPACE,
+                'namespace',
+            ),
+        );
         assert($node instanceof DOMElement);
 
         $node->setAttribute('name', $namespace);
@@ -71,10 +59,5 @@ final readonly class Unit
         assert($node instanceof DOMElement);
 
         return new Method($node, $name);
-    }
-
-    private function setName(string $name): void
-    {
-        $this->contextNode->setAttribute('name', $name);
     }
 }


### PR DESCRIPTION
Reducing the api surface along the way and reducing risk of incompletly constructed objects