### PR TITLE
Remove unnecessary indirection via dom()-method

### DIFF
--- a/src/Report/Xml/File.php
+++ b/src/Report/Xml/File.php
@@ -19,7 +19,7 @@ use DOMNode;
  */
 class File
 {
-    private readonly DOMDocument $dom;
+    protected readonly DOMDocument $dom;
     private readonly DOMElement $contextNode;
     private ?DOMNode $lineCoverage = null;
 
@@ -70,10 +70,5 @@ class File
     protected function contextNode(): DOMElement
     {
         return $this->contextNode;
-    }
-
-    protected function dom(): DOMDocument
-    {
-        return $this->dom;
     }
 }

--- a/src/Report/Xml/Node.php
+++ b/src/Report/Xml/Node.php
@@ -18,18 +18,13 @@ use DOMElement;
  */
 abstract class Node
 {
-    private readonly DOMDocument $dom;
+    protected readonly DOMDocument $dom;
     private readonly DOMElement $contextNode;
 
     public function __construct(DOMElement $context)
     {
         $this->dom         = $context->ownerDocument;
         $this->contextNode = $context;
-    }
-
-    public function dom(): DOMDocument
-    {
-        return $this->dom;
     }
 
     public function totals(): Totals
@@ -52,7 +47,7 @@ abstract class Node
 
     public function addDirectory(string $name): Directory
     {
-        $dirNode = $this->dom()->createElementNS(
+        $dirNode = $this->dom->createElementNS(
             Facade::XML_NAMESPACE,
             'directory',
         );
@@ -65,7 +60,7 @@ abstract class Node
 
     public function addFile(string $name, string $href): File
     {
-        $fileNode = $this->dom()->createElementNS(
+        $fileNode = $this->dom->createElementNS(
             Facade::XML_NAMESPACE,
             'file',
         );

--- a/src/Report/Xml/Project.php
+++ b/src/Report/Xml/Project.php
@@ -48,14 +48,14 @@ final class Project extends Node
         string $phpUnitVersion,
         string $coverageVersion
     ): void {
-        $buildNode = $this->dom()->getElementsByTagNameNS(
+        $buildNode = $this->dom->getElementsByTagNameNS(
             Facade::XML_NAMESPACE,
             'build',
         )->item(0);
 
         if ($buildNode === null) {
-            $buildNode = $this->dom()->documentElement->appendChild(
-                $this->dom()->createElementNS(
+            $buildNode = $this->dom->documentElement->appendChild(
+                $this->dom->createElementNS(
                     Facade::XML_NAMESPACE,
                     'build',
                 ),
@@ -76,7 +76,7 @@ final class Project extends Node
     public function tests(): Tests
     {
         $testsNode = $this->contextNode()->appendChild(
-            $this->dom()->createElementNS(
+            $this->dom->createElementNS(
                 Facade::XML_NAMESPACE,
                 'tests',
             ),
@@ -91,6 +91,6 @@ final class Project extends Node
     {
         $this->contextNode()->setAttribute('source', $this->directory);
 
-        return $this->dom();
+        return $this->dom;
     }
 }

--- a/src/Report/Xml/Report.php
+++ b/src/Report/Xml/Report.php
@@ -42,7 +42,7 @@ final class Report extends File
         $this->contextNode()->setAttribute('name', basename($this->name));
         $this->contextNode()->setAttribute('path', dirname($this->name));
 
-        return $this->dom();
+        return $this->dom;
     }
 
     public function functionObject(
@@ -56,7 +56,7 @@ final class Report extends File
         string $crap
     ): void {
         $node = $this->contextNode()->appendChild(
-            $this->dom()->createElementNS(
+            $this->dom->createElementNS(
                 Facade::XML_NAMESPACE,
                 'function',
             ),
@@ -86,7 +86,7 @@ final class Report extends File
         float $crap
     ): Unit {
         $node = $this->contextNode()->appendChild(
-            $this->dom()->createElementNS(
+            $this->dom->createElementNS(
                 Facade::XML_NAMESPACE,
                 'class',
             ),
@@ -106,7 +106,7 @@ final class Report extends File
         float $crap
     ): Unit {
         $node = $this->contextNode()->appendChild(
-            $this->dom()->createElementNS(
+            $this->dom->createElementNS(
                 Facade::XML_NAMESPACE,
                 'trait',
             ),
@@ -120,7 +120,7 @@ final class Report extends File
     public function source(): Source
     {
         $source = $this->contextNode()->appendChild(
-            $this->dom()->createElementNS(
+            $this->dom->createElementNS(
                 Facade::XML_NAMESPACE,
                 'source',
             ),


### PR DESCRIPTION
unifies the access pattern, as some places where already directly working with the property, while others accessed it via dom()