### PR TITLE
Drop DOM dependency in XML Report

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "sebastian/environment": "^8.0.3",
         "sebastian/lines-of-code": "^4.0",
         "sebastian/version": "^6.0",
-        "theseer/tokenizer": "^1.3.1"
+        "theseer/tokenizer": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.4.4"

--- a/src/Report/Xml/Coverage.php
+++ b/src/Report/Xml/Coverage.php
@@ -9,7 +9,6 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use DOMElement;
 use XMLWriter;
 
 /**
@@ -17,20 +16,21 @@ use XMLWriter;
  */
 final class Coverage
 {
-    private readonly DOMElement $contextNode;
+    private readonly XMLWriter $xmlWriter;
     private readonly string $line;
 
-    public function __construct(DOMElement $context, string $line)
-    {
-        $this->contextNode = $context;
-        $this->line        = $line;
+    public function __construct(
+        XMLWriter $xmlWriter,
+        string $line
+    ) {
+        $this->xmlWriter = $xmlWriter;
+        $this->line      = $line;
     }
 
     public function finalize(array $tests): void
     {
-        $writer = new XMLWriter;
-        $writer->openMemory();
-        $writer->startElementNs(null, $this->contextNode->nodeName, Facade::XML_NAMESPACE);
+        $writer = $this->xmlWriter;
+        $writer->startElement('line');
         $writer->writeAttribute('nr', $this->line);
 
         foreach ($tests as $test) {
@@ -39,13 +39,5 @@ final class Coverage
             $writer->endElement();
         }
         $writer->endElement();
-
-        $fragment = $this->contextNode->ownerDocument->createDocumentFragment();
-        $fragment->appendXML($writer->outputMemory());
-
-        $this->contextNode->parentNode->replaceChild(
-            $fragment,
-            $this->contextNode,
-        );
     }
 }

--- a/src/Report/Xml/File.php
+++ b/src/Report/Xml/File.php
@@ -9,66 +9,32 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use function assert;
-use DOMDocument;
-use DOMElement;
-use DOMNode;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 class File
 {
-    protected readonly DOMDocument $dom;
-    private readonly DOMElement $contextNode;
-    private ?DOMNode $lineCoverage = null;
+    protected XMLWriter $xmlWriter;
 
-    public function __construct(DOMElement $context)
+    public function __construct(XMLWriter $xmlWriter)
     {
-        $this->dom         = $context->ownerDocument;
-        $this->contextNode = $context;
+        $this->xmlWriter = $xmlWriter;
+    }
+
+    public function getWriter(): XMLWriter
+    {
+        return $this->xmlWriter;
     }
 
     public function totals(): Totals
     {
-        $totalsContainer = $this->contextNode->appendChild(
-            $this->dom->createElementNS(
-                Facade::XML_NAMESPACE,
-                'totals',
-            ),
-        );
-
-        assert($totalsContainer instanceof DOMElement);
-
-        return new Totals($totalsContainer);
+        return new Totals($this->xmlWriter);
     }
 
     public function lineCoverage(string $line): Coverage
     {
-        if ($this->lineCoverage === null) {
-            $this->lineCoverage = $this->contextNode->appendChild(
-                $this->dom->createElementNS(
-                    Facade::XML_NAMESPACE,
-                    'coverage',
-                ),
-            );
-        }
-        assert($this->lineCoverage instanceof DOMElement);
-
-        $lineNode = $this->lineCoverage->appendChild(
-            $this->dom->createElementNS(
-                Facade::XML_NAMESPACE,
-                'line',
-            ),
-        );
-
-        assert($lineNode instanceof DOMElement);
-
-        return new Coverage($lineNode, $line);
-    }
-
-    protected function contextNode(): DOMElement
-    {
-        return $this->contextNode;
+        return new Coverage($this->xmlWriter, $line);
     }
 }

--- a/src/Report/Xml/Method.php
+++ b/src/Report/Xml/Method.php
@@ -9,17 +9,17 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use DOMElement;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final readonly class Method
 {
-    private DOMElement $contextNode;
+    private XMLWriter $xmlWriter;
 
     public function __construct(
-        DOMElement $context,
+        XMLWriter $xmlWriter,
         string $name,
         string $signature,
         string $start,
@@ -29,21 +29,21 @@ final readonly class Method
         string $coverage,
         string $crap
     ) {
-        $this->contextNode = $context;
+        $this->xmlWriter = $xmlWriter;
 
-        $this->contextNode->setAttribute('name', $name);
-        $this->contextNode->setAttribute('signature', $signature);
+        $this->xmlWriter->writeAttribute('name', $name);
+        $this->xmlWriter->writeAttribute('signature', $signature);
 
-        $this->contextNode->setAttribute('start', $start);
+        $this->xmlWriter->writeAttribute('start', $start);
 
         if ($end !== null) {
-            $this->contextNode->setAttribute('end', $end);
+            $this->xmlWriter->writeAttribute('end', $end);
         }
 
-        $this->contextNode->setAttribute('crap', $crap);
+        $this->xmlWriter->writeAttribute('crap', $crap);
 
-        $this->contextNode->setAttribute('executable', $executable);
-        $this->contextNode->setAttribute('executed', $executed);
-        $this->contextNode->setAttribute('coverage', $coverage);
+        $this->xmlWriter->writeAttribute('executable', $executable);
+        $this->xmlWriter->writeAttribute('executed', $executed);
+        $this->xmlWriter->writeAttribute('coverage', $coverage);
     }
 }

--- a/src/Report/Xml/Node.php
+++ b/src/Report/Xml/Node.php
@@ -9,72 +9,37 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use function assert;
-use DOMDocument;
-use DOMElement;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 abstract class Node
 {
-    protected readonly DOMDocument $dom;
-    private readonly DOMElement $contextNode;
+    protected readonly XMLWriter $xmlWriter;
 
-    public function __construct(DOMElement $context)
+    public function __construct(XMLWriter $xmlWriter)
     {
-        $this->dom         = $context->ownerDocument;
-        $this->contextNode = $context;
+        $this->xmlWriter = $xmlWriter;
     }
 
     public function totals(): Totals
     {
-        $totalsContainer = $this->contextNode()->firstChild;
-
-        if ($totalsContainer === null) {
-            $totalsContainer = $this->contextNode()->appendChild(
-                $this->dom->createElementNS(
-                    Facade::XML_NAMESPACE,
-                    'totals',
-                ),
-            );
-        }
-
-        assert($totalsContainer instanceof DOMElement);
-
-        return new Totals($totalsContainer);
+        return new Totals($this->xmlWriter);
     }
 
-    public function addDirectory(string $name): Directory
+    public function addDirectory(): Directory
     {
-        $dirNode = $this->dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'directory',
-        );
-
-        $dirNode->setAttribute('name', $name);
-        $this->contextNode()->appendChild($dirNode);
-
-        return new Directory($dirNode);
+        return new Directory($this->xmlWriter);
     }
 
-    public function addFile(string $name, string $href, string $hash): File
+    public function addFile(): File
     {
-        $fileNode = $this->dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'file',
-        );
-
-        $fileNode->setAttribute('name', $name);
-        $fileNode->setAttribute('href', $href);
-        $fileNode->setAttribute('hash', $hash);
-        $this->contextNode()->appendChild($fileNode);
-
-        return new File($fileNode);
+        return new File($this->xmlWriter);
     }
 
-    protected function contextNode(): DOMElement
+    public function getWriter(): XMLWriter
     {
-        return $this->contextNode;
+        return $this->xmlWriter;
     }
 }

--- a/src/Report/Xml/Source.php
+++ b/src/Report/Xml/Source.php
@@ -9,33 +9,26 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use DOMElement;
 use TheSeer\Tokenizer\NamespaceUri;
 use TheSeer\Tokenizer\Tokenizer;
 use TheSeer\Tokenizer\XMLSerializer;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final readonly class Source
 {
-    private DOMElement $context;
+    private XMLWriter $xmlWriter;
 
-    public function __construct(DOMElement $context)
+    public function __construct(XMLWriter $xmlWriter)
     {
-        $this->context = $context;
+        $this->xmlWriter = $xmlWriter;
     }
 
     public function setSourceCode(string $source): void
     {
-        $context = $this->context;
-
         $tokens = (new Tokenizer)->parse($source);
-        $srcDom = (new XMLSerializer(new NamespaceUri(Facade::XML_NAMESPACE)))->toDom($tokens);
-
-        $context->parentNode->replaceChild(
-            $context->ownerDocument->importNode($srcDom->documentElement, true),
-            $context,
-        );
+        (new XMLSerializer(new NamespaceUri(Facade::XML_NAMESPACE)))->appendToWriter($this->xmlWriter, $tokens);
     }
 }

--- a/src/Report/Xml/Tests.php
+++ b/src/Report/Xml/Tests.php
@@ -9,10 +9,9 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use function assert;
 use function sprintf;
-use DOMElement;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
@@ -21,11 +20,11 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
  */
 final readonly class Tests
 {
-    private DOMElement $contextNode;
+    private readonly XMLWriter $xmlWriter;
 
-    public function __construct(DOMElement $context)
+    public function __construct(XMLWriter $xmlWriter)
     {
-        $this->contextNode = $context;
+        $this->xmlWriter = $xmlWriter;
     }
 
     /**
@@ -33,18 +32,13 @@ final readonly class Tests
      */
     public function addTest(string $test, array $result): void
     {
-        $node = $this->contextNode->appendChild(
-            $this->contextNode->ownerDocument->createElementNS(
-                Facade::XML_NAMESPACE,
-                'test',
-            ),
-        );
+        $this->xmlWriter->startElement('test');
 
-        assert($node instanceof DOMElement);
+        $this->xmlWriter->writeAttribute('name', $test);
+        $this->xmlWriter->writeAttribute('size', $result['size']);
+        $this->xmlWriter->writeAttribute('status', $result['status']);
+        $this->xmlWriter->writeAttribute('time', sprintf('%F', $result['time']));
 
-        $node->setAttribute('name', $test);
-        $node->setAttribute('size', $result['size']);
-        $node->setAttribute('status', $result['status']);
-        $node->setAttribute('time', sprintf('%F', $result['time']));
+        $this->xmlWriter->endElement();
     }
 }

--- a/src/Report/Xml/Totals.php
+++ b/src/Report/Xml/Totals.php
@@ -10,106 +10,86 @@
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
 use function sprintf;
-use DOMElement;
 use SebastianBergmann\CodeCoverage\Util\Percentage;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final readonly class Totals
 {
-    private DOMElement $linesNode;
-    private DOMElement $methodsNode;
-    private DOMElement $functionsNode;
-    private DOMElement $classesNode;
-    private DOMElement $traitsNode;
+    private XMLWriter $xmlWriter;
 
-    public function __construct(DOMElement $container)
+    public function __construct(XMLWriter $xmlWriter)
     {
-        $dom = $container->ownerDocument;
-
-        $this->linesNode = $dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'lines',
-        );
-
-        $this->methodsNode = $dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'methods',
-        );
-
-        $this->functionsNode = $dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'functions',
-        );
-
-        $this->classesNode = $dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'classes',
-        );
-
-        $this->traitsNode = $dom->createElementNS(
-            Facade::XML_NAMESPACE,
-            'traits',
-        );
-
-        $container->appendChild($this->linesNode);
-        $container->appendChild($this->methodsNode);
-        $container->appendChild($this->functionsNode);
-        $container->appendChild($this->classesNode);
-        $container->appendChild($this->traitsNode);
+        $this->xmlWriter = $xmlWriter;
     }
 
     public function setNumLines(int $loc, int $cloc, int $ncloc, int $executable, int $executed): void
     {
-        $this->linesNode->setAttribute('total', (string) $loc);
-        $this->linesNode->setAttribute('comments', (string) $cloc);
-        $this->linesNode->setAttribute('code', (string) $ncloc);
-        $this->linesNode->setAttribute('executable', (string) $executable);
-        $this->linesNode->setAttribute('executed', (string) $executed);
-        $this->linesNode->setAttribute(
+        $this->xmlWriter->startElement('lines');
+        $this->xmlWriter->writeAttribute('total', (string) $loc);
+        $this->xmlWriter->writeAttribute('comments', (string) $cloc);
+        $this->xmlWriter->writeAttribute('code', (string) $ncloc);
+        $this->xmlWriter->writeAttribute('executable', (string) $executable);
+        $this->xmlWriter->writeAttribute('executed', (string) $executed);
+        $this->xmlWriter->writeAttribute(
             'percent',
             $executable === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($executed, $executable)->asFloat()),
         );
+        $this->xmlWriter->endElement();
     }
 
     public function setNumClasses(int $count, int $tested): void
     {
-        $this->classesNode->setAttribute('count', (string) $count);
-        $this->classesNode->setAttribute('tested', (string) $tested);
-        $this->classesNode->setAttribute(
+        $this->xmlWriter->startElement('classes');
+        $this->xmlWriter->writeAttribute('count', (string) $count);
+        $this->xmlWriter->writeAttribute('tested', (string) $tested);
+        $this->xmlWriter->writeAttribute(
             'percent',
             $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
         );
+        $this->xmlWriter->endElement();
     }
 
     public function setNumTraits(int $count, int $tested): void
     {
-        $this->traitsNode->setAttribute('count', (string) $count);
-        $this->traitsNode->setAttribute('tested', (string) $tested);
-        $this->traitsNode->setAttribute(
+        $this->xmlWriter->startElement('traits');
+        $this->xmlWriter->writeAttribute('count', (string) $count);
+        $this->xmlWriter->writeAttribute('tested', (string) $tested);
+        $this->xmlWriter->writeAttribute(
             'percent',
             $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
         );
+        $this->xmlWriter->endElement();
     }
 
     public function setNumMethods(int $count, int $tested): void
     {
-        $this->methodsNode->setAttribute('count', (string) $count);
-        $this->methodsNode->setAttribute('tested', (string) $tested);
-        $this->methodsNode->setAttribute(
+        $this->xmlWriter->startElement('methods');
+        $this->xmlWriter->writeAttribute('count', (string) $count);
+        $this->xmlWriter->writeAttribute('tested', (string) $tested);
+        $this->xmlWriter->writeAttribute(
             'percent',
             $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
         );
+        $this->xmlWriter->endElement();
     }
 
     public function setNumFunctions(int $count, int $tested): void
     {
-        $this->functionsNode->setAttribute('count', (string) $count);
-        $this->functionsNode->setAttribute('tested', (string) $tested);
-        $this->functionsNode->setAttribute(
+        $this->xmlWriter->startElement('functions');
+        $this->xmlWriter->writeAttribute('count', (string) $count);
+        $this->xmlWriter->writeAttribute('tested', (string) $tested);
+        $this->xmlWriter->writeAttribute(
             'percent',
             $count === 0 ? '0' : sprintf('%01.2F', Percentage::fromFractionAndTotal($tested, $count)->asFloat()),
         );
+        $this->xmlWriter->endElement();
+    }
+
+    public function getWriter(): XMLWriter
+    {
+        return $this->xmlWriter;
     }
 }

--- a/src/Report/Xml/Unit.php
+++ b/src/Report/Xml/Unit.php
@@ -9,18 +9,17 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Xml;
 
-use function assert;
-use DOMElement;
+use XMLWriter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
 final readonly class Unit
 {
-    private DOMElement $contextNode;
+    private XMLWriter $xmlWriter;
 
     public function __construct(
-        DOMElement $context,
+        XMLWriter $xmlWriter,
         string $name,
         string $namespace,
         int $start,
@@ -28,23 +27,17 @@ final readonly class Unit
         int $executed,
         float $crap
     ) {
-        $this->contextNode = $context;
+        $this->xmlWriter = $xmlWriter;
 
-        $this->contextNode->setAttribute('name', $name);
-        $this->contextNode->setAttribute('start', (string) $start);
-        $this->contextNode->setAttribute('executable', (string) $executable);
-        $this->contextNode->setAttribute('executed', (string) $executed);
-        $this->contextNode->setAttribute('crap', (string) $crap);
+        $this->xmlWriter->writeAttribute('name', $name);
+        $this->xmlWriter->writeAttribute('start', (string) $start);
+        $this->xmlWriter->writeAttribute('executable', (string) $executable);
+        $this->xmlWriter->writeAttribute('executed', (string) $executed);
+        $this->xmlWriter->writeAttribute('crap', (string) $crap);
 
-        $node = $this->contextNode->appendChild(
-            $this->contextNode->ownerDocument->createElementNS(
-                Facade::XML_NAMESPACE,
-                'namespace',
-            ),
-        );
-        assert($node instanceof DOMElement);
-
-        $node->setAttribute('name', $namespace);
+        $this->xmlWriter->startElement('namespace');
+        $this->xmlWriter->writeAttribute('name', $namespace);
+        $this->xmlWriter->endElement();
     }
 
     public function addMethod(
@@ -57,17 +50,8 @@ final readonly class Unit
         string $coverage,
         string $crap
     ): void {
-        $node = $this->contextNode->appendChild(
-            $this->contextNode->ownerDocument->createElementNS(
-                Facade::XML_NAMESPACE,
-                'method',
-            ),
-        );
-
-        assert($node instanceof DOMElement);
-
         new Method(
-            $node,
+            $this->xmlWriter,
             $name,
             $signature,
             $start,

--- a/tests/_files/Report/XML/CoverageForBankAccount/BankAccount.php.xml
+++ b/tests/_files/Report/XML/CoverageForBankAccount/BankAccount.php.xml
@@ -35,7 +35,7 @@
         <covered by="BankAccountTest::testDepositWithdrawMoney"/>
       </line>
     </coverage>
-    <source>
+    <source xmlns="https://schema.phpunit.de/coverage/1.0">
       <line no="1">
         <token name="T_OPEN_TAG">&lt;?php</token>
       </line>

--- a/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.xml
+++ b/tests/_files/Report/XML/CoverageForClassWithAnonymousFunction/source_with_class_and_anonymous_function.php.xml
@@ -38,7 +38,7 @@
         <covered by="ClassWithAnonymousFunction"/>
       </line>
     </coverage>
-    <source>
+    <source xmlns="https://schema.phpunit.de/coverage/1.0">
       <line no="1">
         <token name="T_OPEN_TAG">&lt;?php</token>
       </line>
@@ -100,7 +100,7 @@
         <token name="T_FUNCTION">function</token>
         <token name="T_WHITESPACE"> </token>
         <token name="T_OPEN_BRACKET">(</token>
-        <token name="T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG">&amp;</token>
+        <token name="T_AMPERSAND">&amp;</token>
         <token name="T_VARIABLE">$val</token>
         <token name="T_COMMA">,</token>
         <token name="T_WHITESPACE"> </token>

--- a/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/source_with_ignore.php.xml
+++ b/tests/_files/Report/XML/CoverageForFileWithIgnoredLines/source_with_ignore.php.xml
@@ -22,7 +22,7 @@
         <covered by="FileWithIgnoredLines"/>
       </line>
     </coverage>
-    <source>
+    <source xmlns="https://schema.phpunit.de/coverage/1.0">
       <line no="1">
         <token name="T_OPEN_TAG">&lt;?php</token>
       </line>


### PR DESCRIPTION
requires https://github.com/theseer/tokenizer/pull/38

before this PR (using PHPUnit 12.4.4)
```
➜  slow-coverage-xml1 git:(main) ✗ hyperfine 'php coverage-xml.php'           
Benchmark 1: php coverage-xml.php
  Time (mean ± σ):     11.772 s ±  0.550 s    [User: 10.209 s, System: 1.237 s]
  Range (min … max):   11.008 s … 12.568 s    10 runs
```

after this PR:
```
➜  slow-coverage-xml1 git:(main) ✗ hyperfine 'php coverage-xml.php'
Benchmark 1: php coverage-xml.php
  Time (mean ± σ):      5.999 s ±  0.385 s    [User: 5.008 s, System: 0.789 s]
  Range (min … max):    5.647 s …  6.732 s    10 runs
```

---

env

```
php -v
PHP 8.3.28 (cli) (built: Nov 18 2025 22:17:16) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.28, Copyright (c) Zend Technologies
```