### PR TITLE
Coverage-xml cannot contain pcov and xdebug at the same time

### DIFF
--- a/src/Report/Xml/BuildInformation.php
+++ b/src/Report/Xml/BuildInformation.php
@@ -39,14 +39,12 @@ final readonly class BuildInformation
 
         $xmlWriter->startElement('driver');
 
-        if ($runtime->hasXdebug()) {
-            $xmlWriter->writeAttribute('name', 'xdebug');
-            $xmlWriter->writeAttribute('version', phpversion('xdebug'));
-        }
-
         if ($runtime->hasPCOV()) {
             $xmlWriter->writeAttribute('name', 'pcov');
             $xmlWriter->writeAttribute('version', phpversion('pcov'));
+        } elseif ($runtime->hasXdebug()) {
+            $xmlWriter->writeAttribute('name', 'xdebug');
+            $xmlWriter->writeAttribute('version', phpversion('xdebug'));
         }
         $xmlWriter->endElement();
 


### PR DESCRIPTION
attribute name needs to be unique

closes https://github.com/sebastianbergmann/php-code-coverage/issues/1131

---

this regressed in https://github.com/sebastianbergmann/php-code-coverage/commit/5b74f6242eb0baf4414dd15033afd51abc0bb45d which previously used DOM to de-duplicate the attribute name automatically because it just overwrote the previous value