### PR TITLE
`CoversClass` does not transitively target traits used by enumerations

### DIFF
--- a/src/StaticAnalysis/Visitor/CodeUnitFindingVisitor.php
+++ b/src/StaticAnalysis/Visitor/CodeUnitFindingVisitor.php
@@ -105,7 +105,7 @@ final class CodeUnitFindingVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        if (!$node instanceof Class_ && !$node instanceof Trait_) {
+        if (!$node instanceof Class_ && !$node instanceof Enum_ && !$node instanceof Trait_) {
             return null;
         }
 
@@ -396,11 +396,11 @@ final class CodeUnitFindingVisitor extends NodeVisitorAbstract
     /**
      * @param list<non-empty-string> $traits
      */
-    private function postProcessClassOrTrait(Class_|Trait_ $node, array $traits): void
+    private function postProcessClassOrTrait(Class_|Enum_|Trait_ $node, array $traits): void
     {
         $name = $node->namespacedName->toString();
 
-        if ($node instanceof Class_) {
+        if ($node instanceof Class_ || $node instanceof Enum_) {
             assert(isset($this->classes[$name]));
 
             $this->classes[$name] = new \SebastianBergmann\CodeCoverage\StaticAnalysis\Class_(

--- a/tests/_files/source_with_enum_using_trait.php
+++ b/tests/_files/source_with_enum_using_trait.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+namespace SebastianBergmann\CodeCoverage\TestFixture;
+
+trait EnumTrait
+{
+    public function traitMethod(): string
+    {
+        return 'from trait';
+    }
+}
+
+enum EnumWithTrait: string
+{
+    use EnumTrait;
+
+    case Foo = 'foo';
+}

--- a/tests/tests/StaticAnalysis/Visitor/CodeUnitFindingVisitorTest.php
+++ b/tests/tests/StaticAnalysis/Visitor/CodeUnitFindingVisitorTest.php
@@ -255,6 +255,22 @@ final class CodeUnitFindingVisitorTest extends TestCase
         $this->assertArrayHasKey('six', $methods);
     }
 
+    public function testHandlesEnumUsingTrait(): void
+    {
+        $codeUnitFindingVisitor = $this->findCodeUnits(__DIR__ . '/../../../_files/source_with_enum_using_trait.php');
+
+        $classes = $codeUnitFindingVisitor->classes();
+
+        $this->assertCount(1, $classes);
+
+        $enum = $classes['SebastianBergmann\CodeCoverage\TestFixture\EnumWithTrait'];
+
+        $this->assertSame(
+            ['SebastianBergmann\CodeCoverage\TestFixture\EnumTrait'],
+            $enum->traits(),
+        );
+    }
+
     private function findCodeUnits(string $filename): CodeUnitFindingVisitor
     {
         $nodes = (new ParserFactory)->createForHostVersion()->parse(


### PR DESCRIPTION
## Problem

When a **class** uses a trait, `#[CoversClass(TheClass::class)]` transitively whitelists the trait's lines for coverage. When an **enum** uses the same trait, the trait's lines are *not* whitelisted — PHPUnit flags the test as risky:

> This test executed code that is not listed as code to be covered or used: …

This forces authors to add `#[UsesTrait]` or `#[CoversTrait]` to enum tests, which is inconsistent with the class behavior and creates friction with static analysis tools that don't accept those attributes.

A minimal reproduction is available at https://github.com/no-simpler/phpunit-psalm-trit-catch22 (rows 1 vs 4 in its test matrix).

## Root cause

`CodeUnitFindingVisitor::leaveNode()` resolves trait usages only for `Class_` and `Trait_` nodes. `Enum_` extends `ClassLike` (not `Class_`), so it is excluded by the early-return gate. Enums are correctly discovered in `enterNode()` via `processClass()`, but their trait lists are never populated.

## Changes

Three one-line fixes in `CodeUnitFindingVisitor`:

1. **`leaveNode()`** — include `Enum_` in the gate so enums proceed to trait resolution
2. **`postProcessClassOrTrait()` signature** — widen the type union to accept `Enum_`
3. **`postProcessClassOrTrait()` body** — route `Enum_` into the class branch (enums are stored in `$this->classes`)

Plus a regression test (`testHandlesEnumUsingTrait`) and fixture file mirroring the existing `testHandlesTraitUsingTrait` pattern.

> _Note: This is a copy of [!1145](https://github.com/sebastianbergmann/php-code-coverage/pull/1145), re-created on branch `12.5` to be able to merge as bug fix._