### PR TITLE
Do not treat lines spanned by attributes as executable

### DIFF
--- a/src/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php
@@ -83,7 +83,9 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        if ($node instanceof Node\Stmt\Interface_) {
+        if ($node instanceof Node\Stmt\Interface_ ||
+            $node instanceof Node\Attribute
+        ) {
             foreach (range($node->getStartLine(), $node->getEndLine()) as $line) {
                 $this->unsets[$line] = true;
             }

--- a/tests/_files/source_for_branched_exec_lines.php
+++ b/tests/_files/source_for_branched_exec_lines.php
@@ -609,3 +609,18 @@ final class MyFinalClass extends MyAbstractClass
     {
     }                               // +1
 }
+
+#[\Attribute]
+class AttributeWithCtor
+{
+    public function __construct(array $myArray)
+    {}  // +2
+}
+
+#[AttributeWithCtor(myArray: [
+    'foo' => [
+        'bar' => 'baz',
+    ],
+])]
+class MyClassWithAttribute
+{}


### PR DESCRIPTION
Fix https://github.com/sebastianbergmann/php-code-coverage/issues/1148

Beware the targeted branch is `12.5`, so releases are needed also for `13` and `14` branches.