### PR TITLE
Fixes 1156 (Issue with scalar literals in code coverage)

### DIFF
--- a/src/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php
+++ b/src/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php
@@ -160,6 +160,15 @@ final class ExecutableLinesFindingVisitor extends NodeVisitorAbstract
             return null;
         }
 
+        if ($node instanceof Node\Stmt\Expression &&
+            (
+                $node->expr instanceof Node\Scalar ||
+                $node->expr instanceof Node\Expr\ConstFetch
+            )
+        ) {
+            return null;
+        }
+
         if ($node instanceof Node\Stmt\Enum_ ||
             $node instanceof Node\Stmt\Function_ ||
             $node instanceof Node\Stmt\Class_ ||

--- a/tests/_files/source_with_scalar_literals.php
+++ b/tests/_files/source_with_scalar_literals.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+final class ScalarLiterals
+{
+    public static function testFunction()
+    {
+        'a string';
+        null;
+        $x = 5;
+        true;
+        false;
+        $x += 1;
+        1;
+        1.1;
+        return $x;
+    }
+}

--- a/tests/tests/StaticAnalysis/Visitor/ExecutableLinesFindingVisitorTest.php
+++ b/tests/tests/StaticAnalysis/Visitor/ExecutableLinesFindingVisitorTest.php
@@ -234,6 +234,31 @@ final class ExecutableLinesFindingVisitorTest extends TestCase
         $this->assertArrayHasKey(12, $executableLines);
     }
 
+    #[Ticket('https://github.com/sebastianbergmann/php-code-coverage/issues/1156')]
+    public function testScalarLiteralsNotMarkedAsExecutable(): void
+    {
+        $source                        = file_get_contents(__DIR__ . '/../../../_files/source_with_scalar_literals.php');
+        $parser                        = (new ParserFactory)->createForHostVersion();
+        $nodes                         = $parser->parse($source);
+        $executableLinesFindingVisitor = new ExecutableLinesFindingVisitor($source);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($executableLinesFindingVisitor);
+        $traverser->traverse($nodes);
+
+        $executableLines = $executableLinesFindingVisitor->executableLinesGroupedByBranch();
+
+        $this->assertArrayNotHasKey(6, $executableLines);
+        $this->assertArrayNotHasKey(7, $executableLines);
+        $this->assertArrayNotHasKey(9, $executableLines);
+        $this->assertArrayNotHasKey(10, $executableLines);
+        $this->assertArrayNotHasKey(12, $executableLines);
+        $this->assertArrayNotHasKey(13, $executableLines);
+        $this->assertArrayHasKey(8, $executableLines);
+        $this->assertArrayHasKey(11, $executableLines);
+        $this->assertArrayHasKey(14, $executableLines);
+    }
+
     private function doTestSelfDescribingAssert(string $filename): void
     {
         $source                        = file_get_contents($filename);


### PR DESCRIPTION
This fixes https://github.com/sebastianbergmann/php-code-coverage/issues/1156 by updating ExecutableLinesFindingVisitor.php so that where an expression is solely a string literal, float literal, integer literal (`PHPParser\Node\Scalar`) or `null` / `true` / `false` (`PHPParser\Node\Expr\ConstFetch`); the node is ignored / not marked as executable.