### PR TITLE
Make `Merger::merge()` accept any kind of iterable

### DIFF
--- a/src/Serialization/Merger.php
+++ b/src/Serialization/Merger.php
@@ -12,7 +12,6 @@ namespace SebastianBergmann\CodeCoverage\Serialization;
 use function array_key_exists;
 use function array_merge;
 use DateTimeImmutable;
-use Generator;
 use SebastianBergmann\CodeCoverage\Version;
 
 /**
@@ -23,7 +22,7 @@ use SebastianBergmann\CodeCoverage\Version;
 final readonly class Merger
 {
     /**
-     * @param list<non-empty-string> $paths
+     * @param iterable<non-empty-string> $paths
      *
      * @throws DriverMismatchException
      * @throws EmptyPathListException
@@ -33,48 +32,27 @@ final readonly class Merger
      *
      * @return SerializedCoverage
      */
-    public function merge(array $paths, bool $requireMatchingGitInformation = true, bool $requireMatchingPhpVersion = true, bool $requireMatchingCodeCoverageDriver = true): array
+    public function merge(iterable $paths, bool $requireMatchingGitInformation = true, bool $requireMatchingPhpVersion = true, bool $requireMatchingCodeCoverageDriver = true): array
     {
-        return $this->asyncMerge(
-            $this->createGeneratorFor($paths),
-            $requireMatchingGitInformation,
-            $requireMatchingPhpVersion,
-            $requireMatchingCodeCoverageDriver,
-        );
-    }
+        $first             = null;
+        $refRuntime        = null;
+        $refDriver         = null;
+        $refHasGit         = null;
+        $refGit            = null;
+        $mergedTestResults = null;
+        $runtime           = null;
 
-    /**
-     * @param Generator<non-empty-string> $paths
-     *
-     * @throws DriverMismatchException
-     * @throws EmptyPathListException
-     * @throws GitInformationMismatchException
-     * @throws MixedGitInformationException
-     * @throws RuntimeMismatchException
-     *
-     * @return SerializedCoverage
-     */
-    public function asyncMerge(Generator $paths, bool $requireMatchingGitInformation = true, bool $requireMatchingPhpVersion = true, bool $requireMatchingCodeCoverageDriver = true): array
-    {
-        if (!$paths->valid()) {
-            throw new EmptyPathListException;
-        }
+        foreach ($paths as $path) {
+            $unserializer ??= new Unserializer;
 
-        $unserializer = new Unserializer;
+            $first ??= $unserializer->unserialize($path);
+            $refRuntime ??= $first['buildInformation']['runtime'];
+            $refDriver ??= $first['buildInformation']['phpCodeCoverage']['driverInformation'];
+            $refHasGit ??= array_key_exists('git', $first['buildInformation']);
+            $refGit ??= $first['buildInformation']['git'] ?? null;
 
-        $first = $unserializer->unserialize($paths->current());
-        $paths->next();
-        $refRuntime = $first['buildInformation']['runtime'];
-        $refDriver  = $first['buildInformation']['phpCodeCoverage']['driverInformation'];
-        $refHasGit  = array_key_exists('git', $first['buildInformation']);
-        $refGit     = $first['buildInformation']['git'] ?? null;
-
-        $mergedCoverage    = clone $first['codeCoverage'];
-        $mergedTestResults = [$first['testResults']];
-
-        while ($paths->valid()) {
-            $path = $paths->current();
-            $paths->next();
+            $mergedCoverage ??= clone $first['codeCoverage'];
+            $mergedTestResults ??= [$first['testResults']];
 
             $item    = $unserializer->unserialize($path);
             $runtime = $item['buildInformation']['runtime'];
@@ -124,6 +102,10 @@ final readonly class Merger
             $mergedTestResults[] = $item['testResults'];
         }
 
+        if (!isset($first)) {
+            throw new EmptyPathListException;
+        }
+
         $buildInformation = [
             'timestamp'       => (new DateTimeImmutable)->format('D M j G:i:s T Y'),
             'runtime'         => $refRuntime,
@@ -144,17 +126,5 @@ final readonly class Merger
             'codeCoverage'     => $mergedCoverage,
             'testResults'      => array_merge(...$mergedTestResults),
         ];
-    }
-
-    /**
-     * @template T
-     *
-     * @param array<T> $paths
-     *
-     * @return Generator<T>
-     */
-    private function createGeneratorFor(array $paths): Generator
-    {
-        yield from $paths;
     }
 }

--- a/src/Serialization/Merger.php
+++ b/src/Serialization/Merger.php
@@ -11,8 +11,8 @@ namespace SebastianBergmann\CodeCoverage\Serialization;
 
 use function array_key_exists;
 use function array_merge;
-use function array_slice;
 use DateTimeImmutable;
+use Generator;
 use SebastianBergmann\CodeCoverage\Version;
 
 /**
@@ -35,13 +35,35 @@ final readonly class Merger
      */
     public function merge(array $paths, bool $requireMatchingGitInformation = true, bool $requireMatchingPhpVersion = true, bool $requireMatchingCodeCoverageDriver = true): array
     {
-        if ($paths === []) {
+        return $this->asyncMerge(
+            $this->createGeneratorFor($paths),
+            $requireMatchingGitInformation,
+            $requireMatchingPhpVersion,
+            $requireMatchingCodeCoverageDriver,
+        );
+    }
+
+    /**
+     * @param Generator<non-empty-string> $paths
+     *
+     * @throws DriverMismatchException
+     * @throws EmptyPathListException
+     * @throws GitInformationMismatchException
+     * @throws MixedGitInformationException
+     * @throws RuntimeMismatchException
+     *
+     * @return SerializedCoverage
+     */
+    public function asyncMerge(Generator $paths, bool $requireMatchingGitInformation = true, bool $requireMatchingPhpVersion = true, bool $requireMatchingCodeCoverageDriver = true): array
+    {
+        if (!$paths->valid()) {
             throw new EmptyPathListException;
         }
 
         $unserializer = new Unserializer;
 
-        $first      = $unserializer->unserialize($paths[0]);
+        $first = $unserializer->unserialize($paths->current());
+        $paths->next();
         $refRuntime = $first['buildInformation']['runtime'];
         $refDriver  = $first['buildInformation']['phpCodeCoverage']['driverInformation'];
         $refHasGit  = array_key_exists('git', $first['buildInformation']);
@@ -50,7 +72,10 @@ final readonly class Merger
         $mergedCoverage    = clone $first['codeCoverage'];
         $mergedTestResults = [$first['testResults']];
 
-        foreach (array_slice($paths, 1) as $path) {
+        while ($paths->valid()) {
+            $path = $paths->current();
+            $paths->next();
+
             $item    = $unserializer->unserialize($path);
             $runtime = $item['buildInformation']['runtime'];
 
@@ -119,5 +144,17 @@ final readonly class Merger
             'codeCoverage'     => $mergedCoverage,
             'testResults'      => array_merge(...$mergedTestResults),
         ];
+    }
+
+    /**
+     * @template T
+     *
+     * @param array<T> $paths
+     *
+     * @return Generator<T>
+     */
+    private function createGeneratorFor(array $paths): Generator
+    {
+        yield from $paths;
     }
 }

--- a/src/Serialization/Merger.php
+++ b/src/Serialization/Merger.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\CodeCoverage\Serialization;
 
 use function array_key_exists;
 use function array_merge;
+use function assert;
 use DateTimeImmutable;
 use SebastianBergmann\CodeCoverage\Version;
 
@@ -34,67 +35,30 @@ final readonly class Merger
      */
     public function merge(iterable $paths, bool $requireMatchingGitInformation = true, bool $requireMatchingPhpVersion = true, bool $requireMatchingCodeCoverageDriver = true): array
     {
-        $first             = null;
-        $refRuntime        = null;
-        $refDriver         = null;
-        $refHasGit         = null;
-        $refGit            = null;
-        $mergedTestResults = null;
-        $runtime           = null;
+        $unserializer = new Unserializer;
 
         foreach ($paths as $path) {
-            $unserializer ??= new Unserializer;
+            if (!isset($first, $mergedCoverage, $mergedTestResults)) {
+                $first = $unserializer->unserialize($path);
 
-            $first ??= $unserializer->unserialize($path);
-            $refRuntime ??= $first['buildInformation']['runtime'];
-            $refDriver ??= $first['buildInformation']['phpCodeCoverage']['driverInformation'];
-            $refHasGit ??= array_key_exists('git', $first['buildInformation']);
-            $refGit ??= $first['buildInformation']['git'] ?? null;
+                $mergedCoverage    = clone $first['codeCoverage'];
+                $mergedTestResults = [$first['testResults']];
 
-            $mergedCoverage ??= clone $first['codeCoverage'];
-            $mergedTestResults ??= [$first['testResults']];
+                continue;
+            }
 
-            $item    = $unserializer->unserialize($path);
-            $runtime = $item['buildInformation']['runtime'];
+            $item = $unserializer->unserialize($path);
 
             if ($requireMatchingPhpVersion) {
-                if ($runtime['name'] !== $refRuntime['name'] || $runtime['version'] !== $refRuntime['version']) {
-                    throw new RuntimeMismatchException;
-                }
+                $this->assertPhpVersionMatches($first, $item);
             }
 
             if ($requireMatchingCodeCoverageDriver) {
-                $driver = $item['buildInformation']['phpCodeCoverage']['driverInformation'];
-
-                if ($driver['name'] !== $refDriver['name'] || $driver['version'] !== $refDriver['version']) {
-                    throw new DriverMismatchException;
-                }
+                $this->assertDriverMatches($first, $item);
             }
 
             if ($requireMatchingGitInformation) {
-                $hasGit = array_key_exists('git', $item['buildInformation']);
-
-                if ($hasGit !== $refHasGit) {
-                    throw new MixedGitInformationException;
-                }
-
-                if ($hasGit) {
-                    $git = $item['buildInformation']['git'];
-
-                    foreach (['originUrl', 'branch', 'commit', 'status'] as $field) {
-                        if ($git[$field] !== $refGit[$field]) {
-                            throw new GitInformationMismatchException($field, (string) $refGit[$field], (string) $git[$field]);
-                        }
-                    }
-
-                    if ($git['isClean'] !== $refGit['isClean']) {
-                        throw new GitInformationMismatchException(
-                            'isClean',
-                            $refGit['isClean'] ? 'true' : 'false',
-                            $git['isClean'] ? 'true' : 'false',
-                        );
-                    }
-                }
+                $this->assertGitInformationMatches($first, $item);
             }
 
             $mergedCoverage->merge($item['codeCoverage']);
@@ -106,18 +70,21 @@ final readonly class Merger
             throw new EmptyPathListException;
         }
 
+        assert(isset($mergedCoverage));
+        assert(isset($mergedTestResults));
+
         $buildInformation = [
             'timestamp'       => (new DateTimeImmutable)->format('D M j G:i:s T Y'),
-            'runtime'         => $refRuntime,
+            'runtime'         => $first['buildInformation']['runtime'],
             'phpCodeCoverage' => [
                 'version'             => Version::id(),
                 'serializationFormat' => Serializer::SERIALIZATION_FORMAT,
-                'driverInformation'   => $refDriver,
+                'driverInformation'   => $first['buildInformation']['phpCodeCoverage']['driverInformation'],
             ],
         ];
 
-        if ($refHasGit) {
-            $buildInformation['git'] = $refGit;
+        if (array_key_exists('git', $first['buildInformation'])) {
+            $buildInformation['git'] = $first['buildInformation']['git'];
         }
 
         return [
@@ -126,5 +93,78 @@ final readonly class Merger
             'codeCoverage'     => $mergedCoverage,
             'testResults'      => array_merge(...$mergedTestResults),
         ];
+    }
+
+    /**
+     * @param SerializedCoverage $reference
+     * @param SerializedCoverage $current
+     *
+     * @throws RuntimeMismatchException
+     */
+    private function assertPhpVersionMatches(array $reference, array $current): void
+    {
+        $referenceRuntime = $reference['buildInformation']['runtime'];
+        $currentRuntime   = $current['buildInformation']['runtime'];
+
+        if (
+            $referenceRuntime['name'] !== $currentRuntime['name'] ||
+            $referenceRuntime['version'] !== $currentRuntime['version']
+        ) {
+            throw new RuntimeMismatchException;
+        }
+    }
+
+    /**
+     * @param SerializedCoverage $reference
+     * @param SerializedCoverage $current
+     *
+     * @throws DriverMismatchException
+     */
+    private function assertDriverMatches(array $reference, array $current): void
+    {
+        $referenceDriver = $reference['buildInformation']['phpCodeCoverage']['driverInformation'];
+        $currentDriver   = $current['buildInformation']['phpCodeCoverage']['driverInformation'];
+
+        if (
+            $referenceDriver['name'] !== $currentDriver['name'] ||
+            $referenceDriver['version'] !== $currentDriver['version']
+        ) {
+            throw new DriverMismatchException;
+        }
+    }
+
+    /**
+     * @param SerializedCoverage $reference
+     * @param SerializedCoverage $current
+     *
+     * @throws GitInformationMismatchException
+     * @throws MixedGitInformationException
+     */
+    private function assertGitInformationMatches(array $reference, array $current): void
+    {
+        $refHasGit = array_key_exists('git', $reference['buildInformation']);
+
+        if ($refHasGit !== array_key_exists('git', $current['buildInformation'])) {
+            throw new MixedGitInformationException;
+        }
+
+        if ($refHasGit) {
+            $referenceGit = $reference['buildInformation']['git'];
+            $currentGit   = $current['buildInformation']['git'];
+
+            foreach (['originUrl', 'branch', 'commit', 'status'] as $field) {
+                if ($currentGit[$field] !== $referenceGit[$field]) {
+                    throw new GitInformationMismatchException($field, (string) $referenceGit[$field], (string) $currentGit[$field]);
+                }
+            }
+
+            if ($currentGit['isClean'] !== $referenceGit['isClean']) {
+                throw new GitInformationMismatchException(
+                    'isClean',
+                    $referenceGit['isClean'] ? 'true' : 'false',
+                    $currentGit['isClean'] ? 'true' : 'false',
+                );
+            }
+        }
     }
 }

--- a/tests/tests/Serialization/MergerTest.php
+++ b/tests/tests/Serialization/MergerTest.php
@@ -13,6 +13,7 @@ use const PHP_EOL;
 use function array_replace_recursive;
 use function file_put_contents;
 use function serialize;
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageData;
@@ -45,6 +46,17 @@ final class MergerTest extends TestCase
         $path = $this->writeFile('a.php', $this->makeItem());
 
         $result = (new Merger)->merge([$path]);
+
+        $this->assertArrayHasKey('buildInformation', $result);
+        $this->assertArrayHasKey('basePath', $result);
+        $this->assertArrayHasKey('codeCoverage', $result);
+        $this->assertArrayHasKey('testResults', $result);
+        $this->assertInstanceOf(ProcessedCodeCoverageData::class, $result['codeCoverage']);
+    }
+
+    public function testMergeAsynchronously(): void
+    {
+        $result = (new Merger)->asyncMerge($this->generatePathList());
 
         $this->assertArrayHasKey('buildInformation', $result);
         $this->assertArrayHasKey('basePath', $result);
@@ -282,6 +294,16 @@ final class MergerTest extends TestCase
         $result = (new Merger)->merge([$pathA, $pathB], false);
 
         $this->assertArrayHasKey('codeCoverage', $result);
+    }
+
+    /**
+     * @return Generator<non-empty-string>
+     */
+    private function generatePathList(): Generator
+    {
+        yield $this->writeFile('a.php', $this->makeItem(['basePath' => '/home/user/project']));
+
+        yield $this->writeFile('b.php', $this->makeItem(['basePath' => '/home/user/project']));
     }
 
     /**

--- a/tests/tests/Serialization/MergerTest.php
+++ b/tests/tests/Serialization/MergerTest.php
@@ -54,9 +54,9 @@ final class MergerTest extends TestCase
         $this->assertInstanceOf(ProcessedCodeCoverageData::class, $result['codeCoverage']);
     }
 
-    public function testMergeAsynchronously(): void
+    public function testMergeWithGenerator(): void
     {
-        $result = (new Merger)->asyncMerge($this->generatePathList());
+        $result = (new Merger)->merge($this->generatePathList());
 
         $this->assertArrayHasKey('buildInformation', $result);
         $this->assertArrayHasKey('basePath', $result);


### PR DESCRIPTION
This adds a refactor to the `Merger` class, allowing async merge of serialized coverage results (edit: by leveraging generators), for Paraunit (and similar tools) .

This would help me with https://github.com/facile-it/paraunit/pull/390:
 * allows to merge incoming coverage results just-in-time, and not in bulk at the end of tests execution
 * it has memory advantages, because it allows me to immediately erase the serialized coverage file as soon as it's merged
 * it doesn't change the logic or structure of the method, just switches from `array` (list) to `\Generator`
 * I maintained backward compatibility without code duplication, just by converting the array into a generator internally