### PR TITLE
Filesystem-based targeting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "sebastian/complexity": "^6.0",
         "sebastian/environment": "^9.3.2",
         "sebastian/git-state": "^1.0",
-        "sebastian/lines-of-code": "^5.0.1",
+        "sebastian/lines-of-code": "^5.0.2",
         "sebastian/version": "^7.0",
         "theseer/tokenizer": "^2.0.1"
     },

--- a/src/Test/Target/Directory.php
+++ b/src/Test/Target/Directory.php
@@ -37,7 +37,7 @@ final class Directory extends Target
     /**
      * @return non-empty-string
      */
-    public function directory(): string
+    public function path(): string
     {
         return $this->directory;
     }

--- a/src/Test/Target/Directory.php
+++ b/src/Test/Target/Directory.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Test\Target;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class Directory extends Target
+{
+    /**
+     * @var non-empty-string
+     */
+    private string $directory;
+
+    /**
+     * @param non-empty-string $directory
+     */
+    protected function __construct(string $directory)
+    {
+        $this->directory = $directory;
+    }
+
+    public function isDirectory(): true
+    {
+        return true;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function directory(): string
+    {
+        return $this->directory;
+    }
+
+    public function key(): string
+    {
+        return 'directories';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+        return $this->directory;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+        return 'Directory ' . $this->target();
+    }
+}

--- a/src/Test/Target/DirectoryRecursively.php
+++ b/src/Test/Target/DirectoryRecursively.php
@@ -37,7 +37,7 @@ final class DirectoryRecursively extends Target
     /**
      * @return non-empty-string
      */
-    public function directory(): string
+    public function path(): string
     {
         return $this->directory;
     }

--- a/src/Test/Target/DirectoryRecursively.php
+++ b/src/Test/Target/DirectoryRecursively.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Test\Target;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class DirectoryRecursively extends Target
+{
+    /**
+     * @var non-empty-string
+     */
+    private string $directory;
+
+    /**
+     * @param non-empty-string $directory
+     */
+    protected function __construct(string $directory)
+    {
+        $this->directory = $directory;
+    }
+
+    public function isDirectoryRecursively(): true
+    {
+        return true;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function directory(): string
+    {
+        return $this->directory;
+    }
+
+    public function key(): string
+    {
+        return 'directoriesRecursively';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+        return $this->directory;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+        return 'Directory (recursively) ' . $this->target();
+    }
+}

--- a/src/Test/Target/File.php
+++ b/src/Test/Target/File.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Test\Target;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for phpunit/php-code-coverage
+ */
+final class File extends Target
+{
+    /**
+     * @var non-empty-string
+     */
+    private string $path;
+
+    /**
+     * @param non-empty-string $path
+     */
+    protected function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function isFile(): true
+    {
+        return true;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    public function key(): string
+    {
+        return 'files';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function target(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function description(): string
+    {
+        return 'File ' . $this->target();
+    }
+}

--- a/src/Test/Target/MapBuilder.php
+++ b/src/Test/Target/MapBuilder.php
@@ -15,6 +15,7 @@ use function array_slice;
 use function array_unique;
 use function array_values;
 use function count;
+use function dirname;
 use function explode;
 use function implode;
 use function range;
@@ -53,6 +54,9 @@ final readonly class MapBuilder
         $traits                        = [];
         $methods                       = [];
         $functions                     = [];
+        $files                         = [];
+        $directories                   = [];
+        $directoriesRecursively        = [];
         $reverseLookup                 = [];
 
         foreach ($filter->files() as $file) {
@@ -125,8 +129,8 @@ final readonly class MapBuilder
             }
         }
 
-        foreach ($namespaces as $namespace => $files) {
-            foreach ($files as $file => $lines) {
+        foreach ($namespaces as $namespace => $filesInNamespace) {
+            foreach ($filesInNamespace as $file => $lines) {
                 $namespaces[$namespace][$file] = array_values(array_unique($lines));
             }
         }
@@ -165,6 +169,29 @@ final readonly class MapBuilder
             unset($classesThatExtendClass[$className]);
         }
 
+        foreach ($filter->files() as $file) {
+            $linesOfCode = $analyser->analyse($file)->linesOfCode()->linesOfCode();
+
+            if ($linesOfCode === 0) {
+                continue;
+            }
+
+            $lines = range(1, $linesOfCode);
+
+            $files[$file] = [$file => $lines];
+
+            $parent = dirname($file);
+
+            $directories[$parent][$file] = $lines;
+
+            $ancestor = $parent;
+
+            while ($ancestor !== dirname($ancestor)) {
+                $directoriesRecursively[$ancestor][$file] = $lines;
+                $ancestor                                 = dirname($ancestor);
+            }
+        }
+
         return [
             'namespaces'                    => $namespaces,
             'traits'                        => $traits,
@@ -173,6 +200,9 @@ final readonly class MapBuilder
             'classesThatImplementInterface' => $classesThatImplementInterface,
             'methods'                       => $methods,
             'functions'                     => $functions,
+            'files'                         => $files,
+            'directories'                   => $directories,
+            'directoriesRecursively'        => $directoriesRecursively,
             'reverseLookup'                 => $reverseLookup,
         ];
     }

--- a/src/Test/Target/MapBuilder.php
+++ b/src/Test/Target/MapBuilder.php
@@ -14,6 +14,7 @@ use function array_merge;
 use function array_slice;
 use function array_unique;
 use function array_values;
+use function assert;
 use function count;
 use function dirname;
 use function explode;
@@ -172,9 +173,7 @@ final readonly class MapBuilder
         foreach ($filter->files() as $file) {
             $linesOfCode = $analyser->analyse($file)->linesOfCode()->linesOfCode();
 
-            if ($linesOfCode === 0) {
-                continue;
-            }
+            assert($linesOfCode > 0);
 
             $lines = range(1, $linesOfCode);
 

--- a/src/Test/Target/Mapper.php
+++ b/src/Test/Target/Mapper.php
@@ -13,10 +13,11 @@ use function array_keys;
 use function array_merge;
 use function array_unique;
 use function array_values;
+use function realpath;
 use function strcasecmp;
 
 /**
- * @phpstan-type TargetMap array{namespaces: TargetMapPart, traits: TargetMapPart, classes: TargetMapPart, classesThatExtendClass: TargetMapPart, classesThatImplementInterface: TargetMapPart, methods: TargetMapPart, functions: TargetMapPart, reverseLookup: ReverseLookup}
+ * @phpstan-type TargetMap array{namespaces: TargetMapPart, traits: TargetMapPart, classes: TargetMapPart, classesThatExtendClass: TargetMapPart, classesThatImplementInterface: TargetMapPart, methods: TargetMapPart, functions: TargetMapPart, files: TargetMapPart, directories: TargetMapPart, directoriesRecursively: TargetMapPart, reverseLookup: ReverseLookup}
  * @phpstan-type TargetMapPart array<non-empty-string, array<non-empty-string, list<positive-int>>>
  * @phpstan-type ReverseLookup array<non-empty-string, non-empty-string>
  *
@@ -72,6 +73,16 @@ final readonly class Mapper
     {
         if (isset($this->map[$target->key()][$target->target()])) {
             return $this->map[$target->key()][$target->target()];
+        }
+
+        if ($target->isFile() || $target->isDirectory() || $target->isDirectoryRecursively()) {
+            $resolved = realpath($target->target());
+
+            if ($resolved !== false && isset($this->map[$target->key()][$resolved])) {
+                return $this->map[$target->key()][$resolved];
+            }
+
+            throw new InvalidCodeCoverageTargetException($target);
         }
 
         foreach (array_keys($this->map[$target->key()]) as $key) {

--- a/src/Test/Target/Target.php
+++ b/src/Test/Target/Target.php
@@ -73,6 +73,30 @@ abstract class Target
         return new Trait_($traitName);
     }
 
+    /**
+     * @param non-empty-string $path
+     */
+    public static function forFile(string $path): File
+    {
+        return new File($path);
+    }
+
+    /**
+     * @param non-empty-string $directory
+     */
+    public static function forDirectory(string $directory): Directory
+    {
+        return new Directory($directory);
+    }
+
+    /**
+     * @param non-empty-string $directory
+     */
+    public static function forDirectoryRecursively(string $directory): DirectoryRecursively
+    {
+        return new DirectoryRecursively($directory);
+    }
+
     public function isNamespace(): bool
     {
         return false;
@@ -108,8 +132,23 @@ abstract class Target
         return false;
     }
 
+    public function isFile(): bool
+    {
+        return false;
+    }
+
+    public function isDirectory(): bool
+    {
+        return false;
+    }
+
+    public function isDirectoryRecursively(): bool
+    {
+        return false;
+    }
+
     /**
-     * @return 'classes'|'classesThatExtendClass'|'classesThatImplementInterface'|'functions'|'methods'|'namespaces'|'traits'
+     * @return 'classes'|'classesThatExtendClass'|'classesThatImplementInterface'|'directories'|'directoriesRecursively'|'files'|'functions'|'methods'|'namespaces'|'traits'
      */
     abstract public function key(): string;
 

--- a/tests/_files/Target/file-target-tree/Subdir/Inner.php
+++ b/tests/_files/Target/file-target-tree/Subdir/Inner.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+echo 'inner';

--- a/tests/_files/Target/file-target-tree/Top.php
+++ b/tests/_files/Target/file-target-tree/Top.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+echo 'top';

--- a/tests/tests/FilterProcessorTest.php
+++ b/tests/tests/FilterProcessorTest.php
@@ -458,6 +458,9 @@ final class FilterProcessorTest extends TestCase
             'classesThatImplementInterface' => [],
             'methods'                       => [],
             'functions'                     => [],
+            'files'                         => [],
+            'directories'                   => [],
+            'directoriesRecursively'        => [],
             'reverseLookup'                 => [],
         ];
     }

--- a/tests/tests/Test/Target/MapBuilderTest.php
+++ b/tests/tests/Test/Target/MapBuilderTest.php
@@ -10,6 +10,7 @@
 namespace SebastianBergmann\CodeCoverage\Test\Target;
 
 use function array_merge;
+use function dirname;
 use function range;
 use function realpath;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,13 +38,17 @@ use SebastianBergmann\CodeCoverage\TestFixture\Target\TraitTwo;
 
 /**
  * @phpstan-import-type TargetMap from Mapper
+ * @phpstan-import-type TargetMapPart from Mapper
+ * @phpstan-import-type ReverseLookup from Mapper
+ *
+ * @phpstan-type PartialTargetMap array{namespaces: TargetMapPart, traits: TargetMapPart, classes: TargetMapPart, classesThatExtendClass: TargetMapPart, classesThatImplementInterface: TargetMapPart, methods: TargetMapPart, functions: TargetMapPart, reverseLookup: ReverseLookup}
  */
 #[CoversClass(MapBuilder::class)]
 #[Small]
 final class MapBuilderTest extends TestCase
 {
     /**
-     * @return non-empty-array<non-empty-string, array{0: TargetMap, 1: non-empty-list<non-empty-string>}>
+     * @return non-empty-array<non-empty-string, array{0: PartialTargetMap, 1: non-empty-list<non-empty-string>}>
      */
     public static function provider(): array
     {
@@ -420,13 +425,62 @@ final class MapBuilderTest extends TestCase
     }
 
     /**
-     * @param TargetMap                        $expected,
+     * @param PartialTargetMap                 $expected
      * @param non-empty-list<non-empty-string> $files
      */
     #[DataProvider('provider')]
     public function testBuildsMap(array $expected, array $files): void
     {
-        $this->assertSame($expected, $this->map($files));
+        $this->assertSame($this->withFileAndDirectoryEntries($expected, $files), $this->map($files));
+    }
+
+    public function testBuildsMapForFileAndDirectoryTargets(): void
+    {
+        $top   = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Top.php');
+        $inner = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Subdir/Inner.php');
+
+        $topDir = dirname($top);
+        $subDir = dirname($inner);
+
+        $map = $this->map([$top, $inner]);
+
+        $topLines   = range(1, 4);
+        $innerLines = range(1, 4);
+
+        $this->assertSame(
+            [
+                $top   => [$top => $topLines],
+                $inner => [$inner => $innerLines],
+            ],
+            $map['files'],
+        );
+
+        $this->assertArrayHasKey($topDir, $map['directories']);
+        $this->assertSame(
+            [$top => $topLines],
+            $map['directories'][$topDir],
+        );
+
+        $this->assertArrayHasKey($subDir, $map['directories']);
+        $this->assertSame(
+            [$inner => $innerLines],
+            $map['directories'][$subDir],
+        );
+
+        $this->assertArrayHasKey($topDir, $map['directoriesRecursively']);
+        $this->assertSame(
+            [
+                $top   => $topLines,
+                $inner => $innerLines,
+            ],
+            $map['directoriesRecursively'][$topDir],
+        );
+
+        $this->assertArrayHasKey($subDir, $map['directoriesRecursively']);
+        $this->assertSame(
+            [$inner => $innerLines],
+            $map['directoriesRecursively'][$subDir],
+        );
     }
 
     #[Ticket('https://github.com/sebastianbergmann/php-code-coverage/issues/1066')]
@@ -438,8 +492,16 @@ final class MapBuilderTest extends TestCase
         $dummyWithTrait = self::realpath(__DIR__ . '/../../../_files/Target/regression/1066/DummyWithTrait.php');
         $someTrait      = self::realpath(__DIR__ . '/../../../_files/Target/regression/1066/SomeTrait.php');
 
+        $files = [
+            $baseDummy,
+            $dummy,
+            $dummy2,
+            $dummyWithTrait,
+            $someTrait,
+        ];
+
         $this->assertSame(
-            [
+            $this->withFileAndDirectoryEntries([
                 'namespaces' => [
                     'SebastianBergmann' => [
                         $someTrait      => range(4, 6),
@@ -555,16 +617,8 @@ final class MapBuilderTest extends TestCase
                     $dummyWithTrait . ':15' => DummyWithTrait::class . '::method2',
                     $dummyWithTrait . ':16' => DummyWithTrait::class . '::method2',
                 ],
-            ],
-            $this->map(
-                [
-                    $baseDummy,
-                    $dummy,
-                    $dummy2,
-                    $dummyWithTrait,
-                    $someTrait,
-                ],
-            ),
+            ], $files),
+            $this->map($files),
         );
     }
 
@@ -587,6 +641,60 @@ final class MapBuilderTest extends TestCase
                 false,
             ),
         );
+    }
+
+    /**
+     * @param PartialTargetMap                 $expected
+     * @param non-empty-list<non-empty-string> $files
+     *
+     * @return TargetMap
+     */
+    private function withFileAndDirectoryEntries(array $expected, array $files): array
+    {
+        $filter = new Filter;
+        $filter->includeFiles($files);
+
+        $analyser = new FileAnalyser(new ParsingSourceAnalyser, false, false);
+
+        $filesMap                  = [];
+        $directoriesMap            = [];
+        $directoriesRecursivelyMap = [];
+
+        foreach ($filter->files() as $file) {
+            $linesOfCode = $analyser->analyse($file)->linesOfCode()->linesOfCode();
+
+            if ($linesOfCode === 0) {
+                continue;
+            }
+
+            $lines = range(1, $linesOfCode);
+
+            $filesMap[$file] = [$file => $lines];
+
+            $parent                         = dirname($file);
+            $directoriesMap[$parent][$file] = $lines;
+
+            $ancestor = $parent;
+
+            while ($ancestor !== dirname($ancestor)) {
+                $directoriesRecursivelyMap[$ancestor][$file] = $lines;
+                $ancestor                                    = dirname($ancestor);
+            }
+        }
+
+        return [
+            'namespaces'                    => $expected['namespaces'],
+            'traits'                        => $expected['traits'],
+            'classes'                       => $expected['classes'],
+            'classesThatExtendClass'        => $expected['classesThatExtendClass'],
+            'classesThatImplementInterface' => $expected['classesThatImplementInterface'],
+            'methods'                       => $expected['methods'],
+            'functions'                     => $expected['functions'],
+            'files'                         => $filesMap,
+            'directories'                   => $directoriesMap,
+            'directoriesRecursively'        => $directoriesRecursivelyMap,
+            'reverseLookup'                 => $expected['reverseLookup'],
+        ];
     }
 
     /**

--- a/tests/tests/Test/Target/MapBuilderTest.php
+++ b/tests/tests/Test/Target/MapBuilderTest.php
@@ -10,6 +10,7 @@
 namespace SebastianBergmann\CodeCoverage\Test\Target;
 
 use function array_merge;
+use function assert;
 use function dirname;
 use function range;
 use function realpath;
@@ -663,9 +664,7 @@ final class MapBuilderTest extends TestCase
         foreach ($filter->files() as $file) {
             $linesOfCode = $analyser->analyse($file)->linesOfCode()->linesOfCode();
 
-            if ($linesOfCode === 0) {
-                continue;
-            }
+            assert($linesOfCode > 0);
 
             $lines = range(1, $linesOfCode);
 

--- a/tests/tests/Test/Target/MapperTest.php
+++ b/tests/tests/Test/Target/MapperTest.php
@@ -11,6 +11,9 @@ namespace SebastianBergmann\CodeCoverage\Test\Target;
 
 use function array_keys;
 use function array_merge;
+use function chdir;
+use function dirname;
+use function getcwd;
 use function range;
 use function realpath;
 use function strtolower;
@@ -44,6 +47,9 @@ final class MapperTest extends TestCase
     public static function provider(): array
     {
         $file = self::realpath(__DIR__ . '/../../../_files/source_with_interfaces_classes_traits_functions.php');
+
+        $top   = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Top.php');
+        $inner = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Subdir/Inner.php');
 
         return [
             'class' => [
@@ -192,6 +198,40 @@ final class MapperTest extends TestCase
                     ],
                 ),
             ],
+
+            'file' => [
+                [
+                    $top => range(1, 4),
+                ],
+                TargetCollection::fromArray(
+                    [
+                        Target::forFile($top),
+                    ],
+                ),
+            ],
+
+            'directory (direct children only)' => [
+                [
+                    $top => range(1, 4),
+                ],
+                TargetCollection::fromArray(
+                    [
+                        Target::forDirectory(dirname($top)),
+                    ],
+                ),
+            ],
+
+            'directory (recursively)' => [
+                [
+                    $top   => range(1, 4),
+                    $inner => range(1, 4),
+                ],
+                TargetCollection::fromArray(
+                    [
+                        Target::forDirectoryRecursively(dirname($top)),
+                    ],
+                ),
+            ],
         ];
     }
 
@@ -250,6 +290,30 @@ final class MapperTest extends TestCase
                 TargetCollection::fromArray(
                     [
                         Target::forNamespace('DoesNotExist'),
+                    ],
+                ),
+            ],
+            'file' => [
+                'File /path/that/does/not/exist.php is not a valid target for code coverage',
+                TargetCollection::fromArray(
+                    [
+                        Target::forFile('/path/that/does/not/exist.php'),
+                    ],
+                ),
+            ],
+            'directory' => [
+                'Directory /path/that/does/not/exist is not a valid target for code coverage',
+                TargetCollection::fromArray(
+                    [
+                        Target::forDirectory('/path/that/does/not/exist'),
+                    ],
+                ),
+            ],
+            'directory (recursively)' => [
+                'Directory (recursively) /path/that/does/not/exist is not a valid target for code coverage',
+                TargetCollection::fromArray(
+                    [
+                        Target::forDirectoryRecursively('/path/that/does/not/exist'),
                     ],
                 ),
             ],
@@ -329,6 +393,51 @@ final class MapperTest extends TestCase
         );
     }
 
+    public function testRelativeFileTargetIsResolvedViaRealpath(): void
+    {
+        $top    = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Top.php');
+        $mapper = $this->mapper([$top]);
+
+        $previousCwd = self::getcwd();
+        chdir(dirname($top));
+
+        try {
+            $this->assertSame(
+                [$top => range(1, 4)],
+                $mapper->mapTarget(Target::forFile('./Top.php')),
+            );
+        } finally {
+            chdir($previousCwd);
+        }
+    }
+
+    public function testRelativeDirectoryTargetIsResolvedViaRealpath(): void
+    {
+        $top    = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Top.php');
+        $inner  = self::realpath(__DIR__ . '/../../../_files/Target/file-target-tree/Subdir/Inner.php');
+        $mapper = $this->mapper([$top, $inner]);
+
+        $previousCwd = self::getcwd();
+        chdir(dirname($top, 2));
+
+        try {
+            $this->assertSame(
+                [$top => range(1, 4)],
+                $mapper->mapTarget(Target::forDirectory('./file-target-tree')),
+            );
+
+            $this->assertSame(
+                [
+                    $top   => range(1, 4),
+                    $inner => range(1, 4),
+                ],
+                $mapper->mapTarget(Target::forDirectoryRecursively('./file-target-tree')),
+            );
+        } finally {
+            chdir($previousCwd);
+        }
+    }
+
     public function testLineOfCodeInGlobalScopeDoesNotBelongToCodeUnit(): void
     {
         $file   = self::realpath(__DIR__ . '/../../../_files/source_without_ignore.php');
@@ -378,5 +487,19 @@ final class MapperTest extends TestCase
         }
 
         return $realpath;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function getcwd(): string
+    {
+        $cwd = getcwd();
+
+        if ($cwd === false) {
+            throw new RuntimeException('Could not determine current working directory');
+        }
+
+        return $cwd;
     }
 }

--- a/tests/tests/Test/Target/TargetTest.php
+++ b/tests/tests/Test/Target/TargetTest.php
@@ -20,6 +20,9 @@ use SebastianBergmann\CodeCoverage\TestFixture\Target\TraitOne;
 #[CoversClass(Class_::class)]
 #[CoversClass(ClassesThatExtendClass::class)]
 #[CoversClass(ClassesThatImplementInterface::class)]
+#[CoversClass(Directory::class)]
+#[CoversClass(DirectoryRecursively::class)]
+#[CoversClass(File::class)]
 #[CoversClass(Function_::class)]
 #[CoversClass(Method::class)]
 #[CoversClass(Namespace_::class)]
@@ -167,5 +170,74 @@ final class TargetTest extends TestCase
         $this->assertSame('traits', $target->key());
         $this->assertSame($traitName, $target->target());
         $this->assertSame('Trait ' . $traitName, $target->description());
+    }
+
+    public function testCanBeFile(): void
+    {
+        $path = '/path/to/file.php';
+
+        $target = Target::forFile($path);
+
+        $this->assertTrue($target->isFile());
+        $this->assertFalse($target->isClass());
+        $this->assertFalse($target->isClassesThatExtendClass());
+        $this->assertFalse($target->isClassesThatImplementInterface());
+        $this->assertFalse($target->isDirectory());
+        $this->assertFalse($target->isDirectoryRecursively());
+        $this->assertFalse($target->isFunction());
+        $this->assertFalse($target->isMethod());
+        $this->assertFalse($target->isNamespace());
+        $this->assertFalse($target->isTrait());
+
+        $this->assertSame($path, $target->path());
+        $this->assertSame('files', $target->key());
+        $this->assertSame($path, $target->target());
+        $this->assertSame('File ' . $path, $target->description());
+    }
+
+    public function testCanBeDirectory(): void
+    {
+        $directory = '/path/to/directory';
+
+        $target = Target::forDirectory($directory);
+
+        $this->assertTrue($target->isDirectory());
+        $this->assertFalse($target->isClass());
+        $this->assertFalse($target->isClassesThatExtendClass());
+        $this->assertFalse($target->isClassesThatImplementInterface());
+        $this->assertFalse($target->isDirectoryRecursively());
+        $this->assertFalse($target->isFile());
+        $this->assertFalse($target->isFunction());
+        $this->assertFalse($target->isMethod());
+        $this->assertFalse($target->isNamespace());
+        $this->assertFalse($target->isTrait());
+
+        $this->assertSame($directory, $target->directory());
+        $this->assertSame('directories', $target->key());
+        $this->assertSame($directory, $target->target());
+        $this->assertSame('Directory ' . $directory, $target->description());
+    }
+
+    public function testCanBeDirectoryRecursively(): void
+    {
+        $directory = '/path/to/directory';
+
+        $target = Target::forDirectoryRecursively($directory);
+
+        $this->assertTrue($target->isDirectoryRecursively());
+        $this->assertFalse($target->isClass());
+        $this->assertFalse($target->isClassesThatExtendClass());
+        $this->assertFalse($target->isClassesThatImplementInterface());
+        $this->assertFalse($target->isDirectory());
+        $this->assertFalse($target->isFile());
+        $this->assertFalse($target->isFunction());
+        $this->assertFalse($target->isMethod());
+        $this->assertFalse($target->isNamespace());
+        $this->assertFalse($target->isTrait());
+
+        $this->assertSame($directory, $target->directory());
+        $this->assertSame('directoriesRecursively', $target->key());
+        $this->assertSame($directory, $target->target());
+        $this->assertSame('Directory (recursively) ' . $directory, $target->description());
     }
 }

--- a/tests/tests/Test/Target/TargetTest.php
+++ b/tests/tests/Test/Target/TargetTest.php
@@ -212,7 +212,7 @@ final class TargetTest extends TestCase
         $this->assertFalse($target->isNamespace());
         $this->assertFalse($target->isTrait());
 
-        $this->assertSame($directory, $target->directory());
+        $this->assertSame($directory, $target->path());
         $this->assertSame('directories', $target->key());
         $this->assertSame($directory, $target->target());
         $this->assertSame('Directory ' . $directory, $target->description());
@@ -235,7 +235,7 @@ final class TargetTest extends TestCase
         $this->assertFalse($target->isNamespace());
         $this->assertFalse($target->isTrait());
 
-        $this->assertSame($directory, $target->directory());
+        $this->assertSame($directory, $target->path());
         $this->assertSame('directoriesRecursively', $target->key());
         $this->assertSame($directory, $target->target());
         $this->assertSame('Directory (recursively) ' . $directory, $target->description());

--- a/tests/tests/UnintentionallyCoveredCodeCheckerTest.php
+++ b/tests/tests/UnintentionallyCoveredCodeCheckerTest.php
@@ -606,6 +606,9 @@ final class UnintentionallyCoveredCodeCheckerTest extends TestCase
             'classesThatImplementInterface' => [],
             'methods'                       => [],
             'functions'                     => [],
+            'files'                         => [],
+            'directories'                   => [],
+            'directoriesRecursively'        => [],
             'reverseLookup'                 => [],
         ];
     }


### PR DESCRIPTION
PHPUnit wants to introduce `#[CoversFile]`, `#[UsesFile]`, `#[CoversDirectory]`, `#[UsesDirectory]`, `#[CoversDirectoryRecursively]`, and `#[UsesDirectoryRecursively]` attributes so that test classes can scope coverage to a file or directory instead of a class, trait, method, function, or namespace. This unblocks the use cases tracked in https://github.com/sebastianbergmann/phpunit/issues/3794.

Before PHPUnit can implement those attributes, this library needs new `Target` types and the matching entries in the `TargetMap` produced by `MapBuilder`.