### PR TITLE
Filenames in HTML report are not escaped

### DIFF
--- a/src/Report/Html/Renderer.php
+++ b/src/Report/Html/Renderer.php
@@ -9,8 +9,12 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Html;
 
+use const ENT_HTML5;
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
 use function array_pop;
 use function count;
+use function htmlspecialchars;
 use function sprintf;
 use function str_repeat;
 use function substr_count;
@@ -194,7 +198,7 @@ abstract class Renderer
         $template->setVar(
             [
                 'id'               => $node->id(),
-                'full_path'        => $node->pathAsString(),
+                'full_path'        => $this->escapeHtml($node->pathAsString()),
                 'path_to_root'     => $this->pathToRoot($node),
                 'breadcrumbs'      => $this->breadcrumbs($node),
                 'date'             => $this->date,
@@ -205,6 +209,11 @@ abstract class Renderer
                 'high_lower_bound' => (string) $this->thresholds->highLowerBound(),
             ],
         );
+    }
+
+    protected function escapeHtml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
     }
 
     protected function breadcrumbs(AbstractNode $node): string
@@ -240,7 +249,7 @@ abstract class Renderer
     {
         $buffer = sprintf(
             '         <li class="breadcrumb-item active">%s</li>' . "\n",
-            $node->name(),
+            $this->escapeHtml($node->name()),
         );
 
         if ($node instanceof DirectoryNode) {
@@ -255,7 +264,7 @@ abstract class Renderer
         return sprintf(
             '         <li class="breadcrumb-item"><a href="%sindex.html">%s</a></li>' . "\n",
             $pathToRoot,
-            $node->name(),
+            $this->escapeHtml($node->name()),
         );
     }
 

--- a/src/Report/Html/Renderer/BubbleChart.php
+++ b/src/Report/Html/Renderer/BubbleChart.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\CodeCoverage\Report\Html;
 
+use const ENT_QUOTES;
 use const ENT_XML1;
 use function array_filter;
 use function array_map;
@@ -194,12 +195,12 @@ CSS;
                     $item['executableLines'],
                     $item['complexity'],
                 ),
-                ENT_XML1,
+                ENT_QUOTES | ENT_XML1,
             );
 
             $svg .= sprintf(
                 ' <a href="%s"><circle cx="%.1f" cy="%.1f" r="%.1f" class="%s"><title>%s</title></circle></a>' . "\n",
-                htmlspecialchars($item['link'], ENT_XML1),
+                htmlspecialchars($item['link'], ENT_QUOTES | ENT_XML1),
                 $cx,
                 $cy,
                 $r,

--- a/src/Report/Html/Renderer/Dashboard.php
+++ b/src/Report/Html/Renderer/Dashboard.php
@@ -68,7 +68,7 @@ final class Dashboard extends Renderer
         return sprintf(
             '         <li class="breadcrumb-item"><a href="index.html">%s</a></li>' . "\n" .
             '         <li class="breadcrumb-item active">(Dashboard)</li>' . "\n",
-            $node->name(),
+            $this->escapeHtml($node->name()),
         );
     }
 

--- a/src/Report/Html/Renderer/Directory.php
+++ b/src/Report/Html/Renderer/Directory.php
@@ -104,36 +104,37 @@ final class Directory extends Renderer
         if ($total) {
             $data['name'] = 'Total';
         } else {
+            $name         = $this->escapeHtml($node->name());
             $up           = str_repeat('../', count($node->pathAsArray()) - 2);
             $data['icon'] = sprintf('<img src="%s_icons/file-code.svg" class="octicon" />', $up);
 
             if ($node instanceof DirectoryNode) {
                 $data['name'] = sprintf(
                     '<a href="%s/index.html">%s</a>',
-                    $node->name(),
-                    $node->name(),
+                    $name,
+                    $name,
                 );
                 $data['icon'] = sprintf('<img src="%s_icons/file-directory.svg" class="octicon" />', $up);
             } elseif ($this->hasPathCoverage) {
                 $data['name'] = sprintf(
                     '%s <a class="small" href="%s.html">[line]</a> <a class="small" href="%s_branch.html">[branch]</a> <a class="small" href="%s_path.html">[path]</a>',
-                    $node->name(),
-                    $node->name(),
-                    $node->name(),
-                    $node->name(),
+                    $name,
+                    $name,
+                    $name,
+                    $name,
                 );
             } elseif ($this->hasBranchCoverage) {
                 $data['name'] = sprintf(
                     '%s <a class="small" href="%s.html">[line]</a> <a class="small" href="%s_branch.html">[branch]</a>',
-                    $node->name(),
-                    $node->name(),
-                    $node->name(),
+                    $name,
+                    $name,
+                    $name,
                 );
             } else {
                 $data['name'] = sprintf(
                     '<a href="%s.html">%s</a>',
-                    $node->name(),
-                    $node->name(),
+                    $name,
+                    $name,
                 );
             }
         }

--- a/tests/tests/Report/Html/BubbleChartTest.php
+++ b/tests/tests/Report/Html/BubbleChartTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-code-coverage.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeCoverage\Report\Html;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\CodeCoverage\Report\Thresholds;
+
+#[CoversClass(BubbleChart::class)]
+#[Small]
+final class BubbleChartTest extends TestCase
+{
+    public function testHtmlSpecialCharactersInNameAndLinkAreEncoded(): void
+    {
+        $svg = (new BubbleChart(Thresholds::default()))->render(
+            [
+                [
+                    'name'            => 'Foo<Bar> & Baz',
+                    'coverage'        => 50.0,
+                    'executableLines' => 10,
+                    'complexity'      => 3,
+                    'link'            => 'Foo.php.html?a="b"&c',
+                ],
+            ],
+        );
+
+        // The name is rendered as the text of a <title> element.
+        $this->assertStringContainsString('Foo&lt;Bar&gt; &amp; Baz', $svg);
+        $this->assertStringNotContainsString('Foo<Bar>', $svg);
+
+        // The link is rendered as the value of an href attribute, so the double
+        // quote has to be encoded as well.
+        $this->assertStringContainsString('href="Foo.php.html?a=&quot;b&quot;&amp;c"', $svg);
+        $this->assertStringNotContainsString('a="b"', $svg);
+    }
+}

--- a/tests/tests/Report/Html/EndToEndTest.php
+++ b/tests/tests/Report/Html/EndToEndTest.php
@@ -12,12 +12,19 @@ namespace SebastianBergmann\CodeCoverage\Report\Html;
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 use function file_get_contents;
+use function file_put_contents;
 use function iterator_count;
+use function mkdir;
 use function str_replace;
 use FilesystemIterator;
 use PHPUnit\Framework\Attributes\CoversNamespace;
 use PHPUnit\Framework\Attributes\Medium;
 use RegexIterator;
+use SebastianBergmann\CodeCoverage\Data\ProcessedCodeCoverageData;
+use SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData;
+use SebastianBergmann\CodeCoverage\Node\Builder;
+use SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser;
+use SebastianBergmann\CodeCoverage\StaticAnalysis\ParsingSourceAnalyser;
 use SebastianBergmann\CodeCoverage\TestCase;
 
 #[CoversNamespace('SebastianBergmann\CodeCoverage\Report\Html')]
@@ -77,6 +84,38 @@ final class EndToEndTest extends TestCase
         $report->process($this->getCoverageForClassWithAnonymousFunction()->getReport(), TEST_FILES_PATH . 'tmp');
 
         $this->assertFilesEquals($expectedFilesPath, TEST_FILES_PATH . 'tmp');
+    }
+
+    public function testHtmlSpecialCharactersInFileAndDirectoryNamesAreEncoded(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('The filesystem on Windows does not allow "<", ">" or \'"\' in file or directory names');
+        }
+
+        $source = TEST_FILES_PATH . 'tmp' . DIRECTORY_SEPARATOR . 'encoding-source';
+        $target = TEST_FILES_PATH . 'tmp' . DIRECTORY_SEPARATOR . 'encoding-report';
+        $file   = $source . DIRECTORY_SEPARATOR . 'Resource <X & Y>.php';
+        $nested = $source . DIRECTORY_SEPARATOR . 'Group <A & B>' . DIRECTORY_SEPARATOR . 'inner.php';
+
+        mkdir($source . DIRECTORY_SEPARATOR . 'Group <A & B>', 0o777, true);
+        file_put_contents($file, "<?php function f() { return 1; }\n");
+        file_put_contents($nested, "<?php function g() { return 2; }\n");
+
+        $analyser  = new FileAnalyser(new ParsingSourceAnalyser, false, false);
+        $processed = new ProcessedCodeCoverageData;
+
+        foreach ([$file, $nested] as $path) {
+            $processed->initializeUnseenData(RawCodeCoverageData::fromUncoveredFile($path, $analyser));
+        }
+
+        (new Facade)->process((new Builder($analyser))->build($processed, [], ''), $target);
+
+        $index = file_get_contents($target . DIRECTORY_SEPARATOR . 'index.html');
+
+        $this->assertStringContainsString('Resource &lt;X &amp; Y&gt;.php', $index);
+        $this->assertStringContainsString('Group &lt;A &amp; B&gt;', $index);
+        $this->assertStringNotContainsString('Resource <X & Y>.php', $index);
+        $this->assertStringNotContainsString('Group <A & B>', $index);
     }
 
     private function assertFilesEquals(string $expectedFilesPath, string $actualFilesPath): void


### PR DESCRIPTION
Hi,

I've recently been playing around with oddly named files as part of a testing project, and while using the code coverage report, I’ve noticed that they sometimes break the layout. 

The fix feels somewhat minimal, so hopefully this is the right place and a sensible change.

 