### PR TITLE
Do not build code unit map when test has no coverage targets

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -259,10 +259,10 @@ final class CodeCoverage
         $linesToBeUsed    = [];
 
         if ($covers !== false) {
-            $linesToBeCovered = $this->targetMapper()->mapTargets($covers);
+            $linesToBeCovered = $covers->isEmpty() ? [] : $this->targetMapper()->mapTargets($covers);
         }
 
-        if ($linesToBeCovered !== false) {
+        if ($linesToBeCovered !== false && $uses->isNotEmpty()) {
             $linesToBeUsed = $this->targetMapper()->mapTargets($uses);
         }
 
@@ -403,6 +403,10 @@ final class CodeCoverage
 
     public function validate(TargetCollection $targets): ValidationResult
     {
+        if ($targets->isEmpty()) {
+            return ValidationResult::success();
+        }
+
         return (new TargetCollectionValidator)->validate($this->targetMapper(), $targets);
     }
 

--- a/tests/tests/CodeCoverageTest.php
+++ b/tests/tests/CodeCoverageTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData;
 use SebastianBergmann\CodeCoverage\Driver\Driver;
 use SebastianBergmann\CodeCoverage\Driver\Selector;
+use SebastianBergmann\CodeCoverage\Test\Target\TargetCollection;
 use SebastianBergmann\Environment\Runtime;
 
 #[CoversClass(CodeCoverage::class)]
@@ -139,5 +140,10 @@ final class CodeCoverageTest extends TestCase
             $this->getExpectedLineCoverageDataArrayForBankAccount(),
             $coverage->getData()->lineCoverage(),
         );
+    }
+
+    public function testEmptyTargetCollectionIsValidWithoutBuildingCodeUnitMap(): void
+    {
+        $this->assertTrue($this->coverage->validate(TargetCollection::fromArray([]))->isSuccess());
     }
 }


### PR DESCRIPTION
### Problem

- The `Test\Target\Mapper` is built even when no test in the entire suite uses `#[CoversClass]` / `#[UsesClass]`.
- Building the mapper means `MapBuilder::build()` statically analyses **every file in the filter**, so a suite that requests any coverage report pays a full source-tree analysis per PHP process, even though the resulting map is never consumed.
- PHPUnit passes an empty `TargetCollection` to `CodeCoverage::validate()` / `append()` for every test that declares no coverage targets, and both call sites build the mapper before noticing the collection is empty.

Real-world numbers (app with **~24k files** under `<source>`, 5 fast unit tests, `--coverage-cobertura`, PCOV, cold cache):

  | | wall time | peak memory |
  | --- | --- | --- |
  | latest 12.5.7 | 53.5 s | 657 MB |
  | with this change | **10.6 s** | **426 MB** |

Without this patch, we are unable to migrate from PHPUnit 11 to 12+ as our overall CI time for tests inscreases from ~7 mins to ~12 mins.

### Notes:
  - Generated report is byte-identical. 
  - Projects that do use `#[CoversClass]`/`#[UsesClass]` are unaffected.
